### PR TITLE
fix URL formatting to keep path case

### DIFF
--- a/ui/src/utils/format/formatValidURL.ts
+++ b/ui/src/utils/format/formatValidURL.ts
@@ -6,15 +6,21 @@
  */
 export const formatValidURL = (url: string, https = false): string => {
     if (!url) return '';
-    url = url.trim().toLowerCase();
+    url = url.trim();
 
-    if (/^https?:\/\//.test(url)) {
-        if (https && url.startsWith('http://')) {
-            url = url.replace(/^http:\/\//, 'https://');
-        }
-    } else {
-        url = (https ? 'https://' : 'http://') + url;
+    let protocol = https ? 'https' : 'http';
+    let rest = url;
+
+    const hasProtocol = /^https?:\/\//i.test(rest);
+    if (hasProtocol) {
+        const isHttpsURL = /^https:\/\//i.test(rest);
+        protocol = https || isHttpsURL ? 'https' : 'http';
+        rest = rest.replace(/^https?:\/\//i, '');
     }
 
-    return url;
+    const hostEnd = rest.search(/[/?#]/);
+    const hostname = hostEnd === -1 ? rest : rest.slice(0, hostEnd);
+    const tail = hostEnd === -1 ? '' : rest.slice(hostEnd);
+
+    return `${protocol}://${hostname.toLowerCase()}${tail}`;
 };

--- a/ui/tests/utils/format/formatValidURL.test.ts
+++ b/ui/tests/utils/format/formatValidURL.test.ts
@@ -27,8 +27,8 @@ describe('formatValidURL', () => {
         expect(formatValidURL('  example.com  ')).toBe('http://example.com');
     });
 
-    it('should convert to lowercase', () => {
-        expect(formatValidURL('EXAMPLE.COM')).toBe('http://example.com');
+    it('should lowercase scheme and hostname but preserve path case', () => {
+        expect(formatValidURL('HTTP://EXAMPLE.COM/Some/Path')).toBe('http://example.com/Some/Path');
     });
 
     it('should handle URLs with paths', () => {


### PR DESCRIPTION
## Summary
- ensure `formatValidURL` only lowercases the scheme and hostname while preserving path casing
- update tests to reflect partial lowercasing and path preservation

## Testing
- `npm test` *(fails: `/usr/bin/env: ‘npm’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_68a87c65d1708325bb0d88e379d4b4fa