### PR TITLE
feat: add inertia data table options composable

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,10 +3,15 @@
     "version": "1.0.0",
     "main": "src/index.ts",
     "exports": {
-        ".": "./src/index.ts"
+        ".": "./src/index.ts",
+        "./inertia": "./src/inertia.ts"
     },
     "description": "Reusable Vue 3 UI components and library.",
-    "keywords": ["vuejs", "utility", "ui components"],
+    "keywords": [
+        "vuejs",
+        "utility",
+        "ui components"
+    ],
     "scripts": {
         "test": "vitest run",
         "test:watch": "vitest watch",
@@ -23,6 +28,7 @@
         "vue": "^3.4.0"
     },
     "devDependencies": {
+        "@inertiajs/vue3": "^1.0.0",
         "@types/node": "^20.11.5",
         "@vitejs/plugin-vue": "^5.0.3",
         "@vitest/coverage-v8": "^1.2.1",

--- a/ui/src/composables/inertia/index.ts
+++ b/ui/src/composables/inertia/index.ts
@@ -1,0 +1,1 @@
+export { useDataTableOptions } from './useDataTableOptions';

--- a/ui/src/composables/inertia/useDataTableOptions.d.ts
+++ b/ui/src/composables/inertia/useDataTableOptions.d.ts
@@ -1,0 +1,1 @@
+export function useDataTableOptions(routeConfig: any, options?: Record<string, any>, config?: Record<string, any>): any;

--- a/ui/src/composables/inertia/useDataTableOptions.js
+++ b/ui/src/composables/inertia/useDataTableOptions.js
@@ -1,0 +1,121 @@
+import { reactive, toRefs, watch, onBeforeUnmount } from 'vue';
+import debounce from 'lodash/debounce';
+import { router, useForm, usePage } from '@inertiajs/vue3';
+
+const internalOptions = reactive({
+    selectAll: false,
+    selected: [],
+});
+
+const resetSelectionOnPathChange = (state) => {
+    if (typeof window === 'undefined') return;
+
+    const page = usePage();
+    const currentPath = new URL(page.url, window.location.origin).pathname;
+    let nextPath = null;
+
+    router.on('before', (event) => {
+        nextPath = new URL(event.detail.visit.url, window.location.origin).pathname;
+    });
+
+    onBeforeUnmount(() => {
+        if (nextPath && nextPath !== currentPath) {
+            state.selectAll = false;
+            state.selected = [];
+        }
+    });
+};
+
+const resolveRoute = (routeConfig) => {
+    if (typeof routeConfig === 'string') {
+        if (routeConfig.startsWith('http') || routeConfig.startsWith('/')) {
+            return routeConfig;
+        }
+        return route(routeConfig);
+    }
+
+    if (typeof routeConfig === 'object' && routeConfig.name) {
+        return route(routeConfig.name, routeConfig.params || {});
+    }
+
+    throw new Error('Invalid route configuration provided to useDataTableOptions.');
+};
+
+export function useDataTableOptions(routeConfig, options = {}, config = {}) {
+
+    const {
+        only = [],
+        preserveState = true,
+        preserveScroll = false,
+        replace = false,
+        debounceMs = 250,
+        formOptions = {},
+        method = 'get',
+    } = config;
+
+    const mergedOnly = only.includes('options') ? only : ['options', ...only];
+
+    const form = useForm({
+        search: '',
+        perPage: 15,
+        sortField: 'name',
+        sortOrder: 1,
+        filters: {},
+        viewFields: [],
+        ...options
+    });
+
+    const fetchData = () => {
+        const url = resolveRoute(routeConfig);
+        if (method === 'post') {
+            form.post(url, {
+                only: mergedOnly,
+                preserveScroll,
+                preserveState,
+                replace,
+                ...formOptions
+            });
+        } else {
+            router.get(url, {
+                search: form.search,
+                perPage: form.perPage,
+                sortField: form.sortField,
+                sortOrder: form.sortOrder,
+                filters: form.filters,
+                viewFields: form.viewFields,
+                ...formOptions,
+            }, {
+                only: mergedOnly,
+                preserveScroll,
+                preserveState,
+                replace,
+            });
+        }
+    };
+
+    const debouncedUpdate = debounce(fetchData, debounceMs);
+
+    const resetSelection = () => {
+        internalOptions.selectAll = false;
+        internalOptions.selected = [];
+    };
+
+    watch(() => form.search, debouncedUpdate);
+    watch(() => [form.perPage, form.sortField, form.sortOrder], fetchData);
+    watch(() => form.viewFields, fetchData, { deep: true });
+
+    watch(() => form.filters, () => {
+        fetchData();
+        resetSelection();
+    }, { deep: true });
+
+    resetSelectionOnPathChange(internalOptions);
+
+    return {
+        ...toRefs(form),
+        ...toRefs(internalOptions),
+        fetchData,
+        resetSelection,
+        form,
+    };
+}

--- a/ui/src/inertia.ts
+++ b/ui/src/inertia.ts
@@ -1,0 +1,1 @@
+export * from './composables/inertia';


### PR DESCRIPTION
## Summary
- add `useDataTableOptions` composable for Inertia-powered tables
- expose Inertia utilities via optional `inertia` entry point
- remove required peer dependency on `@inertiajs/vue3`

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a882c074588325b3577cebb64cc413