### PR TITLE
docs: add Laravel support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Monorepo containing the Laravel backend and Vue 3 UI components.
 
 - [Backend Guide](docs/backend-guide.md)
 - [Frontend Guide](docs/frontend-guide.md)
+- Laravel
+  - [Support](docs/laravel/support.md)
 - UI
   - [Composables](docs/ui/composables.md)
   - [Utils](docs/ui/utils.md)


### PR DESCRIPTION
## Summary
- reorganize documentation list to add a Laravel section
- link to internal Laravel support doc

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8896a43c08325b144e0e54167064c