### PR TITLE
feat: add utility helpers

### DIFF
--- a/docs/ui/utils.md
+++ b/docs/ui/utils.md
@@ -6,6 +6,7 @@
   - [formatBytes](#formatbytes)
   - [formatDate](#formatdate)
   - [formatDatetime](#formatdatetime)
+  - [formatYmdDate](#formatymddate)
   - [formatNumber](#formatnumber)
   - [formatPercentage](#formatpercentage)
   - [formatSlug](#formatslug)
@@ -17,6 +18,8 @@
   - [isValidURL](#isvalidurl)
 - [Other Utilities](#other-utilities)
   - [isClient](#isclient)
+  - [getRandomItem](#getrandomitem)
+  - [roundTo](#roundto)
 
 ## Format Utilities
 
@@ -80,6 +83,23 @@ import { formatDatetime } from '@tmarois/atlas';
 formatDatetime('2023-01-15T12:00:00');                  // '1/15/2023, 12:00 PM'
 formatDatetime('2023-01-15T12:00:00', 'America/New_York'); // '1/15/2023, 7:00 AM'
 formatDatetime(new Date(2023, 0, 15, 12), 'Europe/London', 'en-GB'); // '15/01/2023, 12:00 pm'
+```
+
+### formatYmdDate
+
+Converts a `YYYY-MM-DD` date string into `MM/DD/YYYY` format.
+
+**Parameters:**
+- `dateString` (string): Date string in `YYYY-MM-DD` format
+
+**Returns:** The formatted date string
+
+**Example:**
+```typescript
+import { formatYmdDate } from '@tmarois/atlas';
+
+formatYmdDate('2023-12-05'); // '12/05/2023'
+formatYmdDate('2023-01-01'); // '01/01/2023'
 ```
 
 ### formatNumber
@@ -270,4 +290,39 @@ import { isClient } from '@tmarois/atlas';
 if (isClient) {
   window.addEventListener('resize', handleResize);
 }
+```
+
+### getRandomItem
+
+Returns a random element from an array.
+
+**Parameters:**
+- `items` (any[]): Array of items
+
+**Returns:** A random element from the array or `undefined` for empty arrays
+
+**Example:**
+```typescript
+import { getRandomItem } from '@tmarois/atlas';
+
+const numbers = [1, 2, 3, 4];
+getRandomItem(numbers); // 1 | 2 | 3 | 4
+```
+
+### roundTo
+
+Rounds a number to a specified number of decimal places.
+
+**Parameters:**
+- `num` (number): The number to round
+- `decimals` (number, optional): Decimal places (default: 2)
+
+**Returns:** The rounded number
+
+**Example:**
+```typescript
+import { roundTo } from '@tmarois/atlas';
+
+roundTo(1.005, 2); // 1.01
+roundTo(123.456, 1); // 123.5
 ```

--- a/ui/src/utils/format/formatYmdDate.ts
+++ b/ui/src/utils/format/formatYmdDate.ts
@@ -1,0 +1,12 @@
+/**
+ * Converts a date string from `YYYY-MM-DD` format to `MM/DD/YYYY`.
+ * @param dateString - The date string in `YYYY-MM-DD` format
+ * @returns The formatted date string or an empty string for invalid input
+ */
+export const formatYmdDate = (dateString: string): string => {
+    if (typeof dateString !== 'string') return '';
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
+    if (!match) return '';
+    const [, year, month, day] = match;
+    return `${month}/${day}/${year}`;
+};

--- a/ui/src/utils/format/index.ts
+++ b/ui/src/utils/format/index.ts
@@ -6,3 +6,4 @@ export * from './formatNumber';
 export * from './formatPercentage';
 export * from './formatSlug';
 export * from './formatValidURL';
+export * from './formatYmdDate';

--- a/ui/src/utils/getRandomItem.ts
+++ b/ui/src/utils/getRandomItem.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns a random element from an array.
+ * @param items - Array of items
+ * @returns A random item from the array or `undefined` if the array is empty or not an array.
+ */
+export const getRandomItem = <T>(items: T[]): T | undefined => {
+    if (!Array.isArray(items) || items.length === 0) return undefined;
+    const index = Math.floor(Math.random() * items.length);
+    return items[index];
+};

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -2,3 +2,5 @@ export * from './format';
 export * from './validate';
 export * from './vue';
 export * from './isClient';
+export * from './getRandomItem';
+export * from './roundTo';

--- a/ui/src/utils/roundTo.ts
+++ b/ui/src/utils/roundTo.ts
@@ -1,0 +1,10 @@
+/**
+ * Rounds a number to a specified number of decimal places.
+ * @param num - The number to round
+ * @param decimals - Number of decimal places (default: 2)
+ * @returns The rounded number
+ */
+export const roundTo = (num: number, decimals = 2): number => {
+    const factor = Math.pow(10, decimals);
+    return Math.round((num + Number.EPSILON) * factor) / factor;
+};

--- a/ui/tests/utils/format/formatYmdDate.test.ts
+++ b/ui/tests/utils/format/formatYmdDate.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { formatYmdDate } from '../../../src/utils/format/formatYmdDate';
+
+describe('formatYmdDate', () => {
+    it('converts YYYY-MM-DD to MM/DD/YYYY', () => {
+        expect(formatYmdDate('2023-12-05')).toBe('12/05/2023');
+    });
+
+    it('returns empty string for invalid format', () => {
+        expect(formatYmdDate('12-05-2023')).toBe('');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(formatYmdDate('')).toBe('');
+    });
+});

--- a/ui/tests/utils/randomItem.test.ts
+++ b/ui/tests/utils/randomItem.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { getRandomItem } from '../../src/utils';
+
+describe('getRandomItem', () => {
+    it('returns an item from the array', () => {
+        const items = [1, 2, 3, 4, 5];
+        const result = getRandomItem(items);
+        expect(items).toContain(result);
+    });
+
+    it('returns undefined for an empty array', () => {
+        expect(getRandomItem([])).toBeUndefined();
+    });
+});

--- a/ui/tests/utils/roundTo.test.ts
+++ b/ui/tests/utils/roundTo.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { roundTo } from '../../src/utils';
+
+describe('roundTo', () => {
+    it('rounds to the specified number of decimals', () => {
+        expect(roundTo(1.005, 2)).toBe(1.01);
+        expect(roundTo(1.2345, 3)).toBe(1.235);
+    });
+
+    it('defaults to two decimals', () => {
+        expect(roundTo(1.2345)).toBe(1.23);
+    });
+
+    it('handles zero decimals', () => {
+        expect(roundTo(10.49, 0)).toBe(10);
+    });
+});


### PR DESCRIPTION
## Summary
- add helpers for picking random array items, rounding numbers, and formatting YYYY-MM-DD dates
- document new utilities and expose them via index
- add comprehensive tests for new helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a88d644b78832594e040c1e23019cc