### PR TITLE
feat: add enum exporter command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,20 @@
 
 Monorepo containing the Laravel backend and Vue 3 UI components.
 
+## Laravel Vue Inertia Bridge
+
+Atlas ships with tooling to bridge Laravel and Vue through Inertia, solving two common pain points:
+
+- **DataTables** – build server-driven options for dynamic tables.
+- **Enums** – export PHP enums for type-safe usage in Vue.
+
 ## Documentation
 
 - [Backend Guide](docs/backend-guide.md)
 - [Frontend Guide](docs/frontend-guide.md)
 - Laravel
   - [Inertia DataTable Options](docs/laravel/inertia-data-table-options.md)
+  - [Enum Exporter](docs/laravel/enum-exporter.md)
   - [Support](docs/laravel/support.md)
 - UI
   - [Composables](docs/ui/composables.md)

--- a/docs/laravel/enum-exporter.md
+++ b/docs/laravel/enum-exporter.md
@@ -1,0 +1,75 @@
+# Enum Exporter
+
+Export Laravel PHP enums to your Vue application so both back and front end share the same enum definitions.
+
+## Setup
+
+Publish the config and review the export paths and format:
+
+```bash
+php artisan vendor:publish --tag=atlas-config
+```
+
+`config/atlas_enums.php` example:
+
+```php
+return [
+    'enum_paths' => [
+        base_path('app/Enums'),
+    ],
+    'output_path' => resource_path('js/enums'),
+    'format' => 'ts', // or 'js'
+    'banner' => '// AUTO-GENERATED FILE. Do not edit by hand.',
+];
+```
+
+## Example
+
+Define a PHP enum:
+
+```php
+namespace App\Enums;
+
+enum UserStatus: string
+{
+    case ACTIVE = 'active';
+    case INACTIVE = 'inactive';
+}
+```
+
+Run the exporter:
+
+```bash
+php artisan atlas:export-enums
+```
+
+The command generates files in `resources/js/enums` (configurable). For TypeScript the result looks like:
+
+`resources/js/enums/UserStatus.ts`
+
+```ts
+export enum UserStatus {
+    ACTIVE = 'active',
+    INACTIVE = 'inactive',
+}
+```
+
+An `index.ts` file is created to re-export all enums:
+
+```ts
+export { UserStatus } from './UserStatus';
+```
+
+## Vue Usage
+
+Import the enums in your components:
+
+```vue
+<script setup lang="ts">
+import { UserStatus } from '@/enums';
+
+const status = ref(UserStatus.ACTIVE);
+</script>
+```
+
+Now enum values stay in sync across Laravel and Vue with full IDE support.

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -19,6 +19,13 @@
             "Atlas\\Laravel\\Tests\\": "tests/"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Atlas\\Laravel\\AtlasServiceProvider"
+            ]
+        }
+    },
     "scripts": {
         "test": "vendor/bin/phpunit"
     }

--- a/laravel/config/atlas_enums.php
+++ b/laravel/config/atlas_enums.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'enum_paths' => [
+        base_path('app/Enums'),
+    ],
+    'output_path' => resource_path('js/enums'),
+    'format' => 'ts',
+    'banner' => '// AUTO-GENERATED FILE. Do not edit by hand.',
+];
+

--- a/laravel/src/AtlasServiceProvider.php
+++ b/laravel/src/AtlasServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Atlas\Laravel;
+
+use Atlas\Laravel\Console\Commands\ExportEnumsCommand;
+use Illuminate\Support\ServiceProvider;
+
+class AtlasServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/atlas_enums.php', 'atlas_enums');
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        $this->publishes([
+            __DIR__.'/../config/atlas_enums.php' => config_path('atlas_enums.php'),
+        ], 'atlas-config');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ExportEnumsCommand::class,
+            ]);
+        }
+    }
+}
+

--- a/laravel/src/Console/Commands/ExportEnumsCommand.php
+++ b/laravel/src/Console/Commands/ExportEnumsCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Atlas\Laravel\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use ReflectionEnum;
+
+class ExportEnumsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'atlas:export-enums';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Export PHP enums to frontend';
+
+    public function handle(): int
+    {
+        $config = config('atlas_enums');
+
+        $enumPaths = $config['enum_paths'] ?? [];
+        $outputPath = $config['output_path'] ?? resource_path('js/enums');
+        $format = $config['format'] ?? 'ts';
+        $banner = $config['banner'] ?? '';
+
+        $exported = [];
+
+        foreach ($enumPaths as $path) {
+            if (! is_dir($path)) {
+                continue;
+            }
+
+            $files = File::allFiles($path);
+
+            foreach ($files as $file) {
+                if ($file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $relativePath = trim(str_replace($path, '', $file->getPathname()), DIRECTORY_SEPARATOR);
+                $relativeDir = dirname($relativePath);
+                $enumName = pathinfo($file->getFilename(), PATHINFO_FILENAME);
+
+                $namespace = $this->getNamespace($file->getPathname());
+                $class = $namespace ? $namespace.'\\'.$enumName : $enumName;
+
+                if (! class_exists($class)) {
+                    require_once $file->getPathname();
+                }
+
+                if (! enum_exists($class)) {
+                    continue;
+                }
+
+                $reflection = new ReflectionEnum($class);
+                $cases = $reflection->getCases();
+
+                $content = $banner ? $banner."\n" : '';
+
+                if ($format === 'ts') {
+                    $content .= "export enum {$enumName} {\n";
+                    foreach ($cases as $case) {
+                        $value = $reflection->isBacked()
+                            ? var_export($case->getBackingValue(), true)
+                            : var_export($case->getName(), true);
+                        $content .= "    {$case->getName()} = {$value},\n";
+                    }
+                    $content .= "}\n";
+                } else {
+                    $content .= "export const {$enumName} = {\n";
+                    foreach ($cases as $case) {
+                        $value = $reflection->isBacked()
+                            ? var_export($case->getBackingValue(), true)
+                            : var_export($case->getName(), true);
+                        $content .= "    {$case->getName()}: {$value},\n";
+                    }
+                    $content .= "};\n";
+                }
+
+                $targetDir = $outputPath.($relativeDir !== '.' ? DIRECTORY_SEPARATOR.$relativeDir : '');
+                File::ensureDirectoryExists($targetDir);
+                $targetFile = $targetDir.DIRECTORY_SEPARATOR.$enumName.'.'.$format;
+                File::put($targetFile, $content);
+
+                $exported[] = [
+                    'name' => $enumName,
+                    'path' => str_replace('\\', '/', ($relativeDir !== '.' ? $relativeDir.'/' : '').$enumName),
+                ];
+            }
+        }
+
+        File::ensureDirectoryExists($outputPath);
+        $indexFile = $outputPath.DIRECTORY_SEPARATOR.'index.'.$format;
+        $index = $banner ? $banner."\n" : '';
+        foreach ($exported as $enum) {
+            $index .= "export { {$enum['name']} } from './{$enum['path']}';\n";
+        }
+        File::put($indexFile, $index);
+
+        $this->info('Enums exported: '.count($exported));
+
+        return self::SUCCESS;
+    }
+
+    protected function getNamespace(string $path): ?string
+    {
+        $content = File::get($path);
+        if (preg_match('/^namespace\s+([^;]+);/m', $content, $matches)) {
+            return trim($matches[1]);
+        }
+
+        return null;
+    }
+}
+

--- a/laravel/tests/Console/ExportEnumsCommandTest.php
+++ b/laravel/tests/Console/ExportEnumsCommandTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Atlas\Laravel\Tests\Console;
+
+use Illuminate\Support\Facades\File;
+use Orchestra\Testbench\TestCase;
+
+class ExportEnumsCommandTest extends TestCase
+{
+    protected string $enumDir;
+    protected string $outputDir;
+
+    protected function getPackageProviders($app): array
+    {
+        return [\Atlas\Laravel\AtlasServiceProvider::class];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->enumDir = sys_get_temp_dir().'/atlas-enums';
+        $this->outputDir = sys_get_temp_dir().'/atlas-enums-output';
+
+        File::deleteDirectory($this->enumDir);
+        File::deleteDirectory($this->outputDir);
+
+        File::ensureDirectoryExists($this->enumDir.'/Billing');
+
+        File::put($this->enumDir.'/Status.php', <<<'PHP'
+<?php
+
+namespace App\Enums;
+
+enum Status: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+}
+PHP);
+
+        File::put($this->enumDir.'/Billing/InvoiceStatus.php', <<<'PHP'
+<?php
+
+namespace App\Enums\Billing;
+
+enum InvoiceStatus: int
+{
+    case Paid = 1;
+    case Unpaid = 0;
+}
+PHP);
+
+        config()->set('atlas_enums.enum_paths', [$this->enumDir]);
+        config()->set('atlas_enums.output_path', $this->outputDir);
+        config()->set('atlas_enums.format', 'ts');
+        config()->set('atlas_enums.banner', '// test');
+    }
+
+    public function test_exports_enums(): void
+    {
+        $this->artisan('atlas:export-enums')->assertExitCode(0);
+
+        $statusFile = $this->outputDir.'/Status.ts';
+        $invoiceFile = $this->outputDir.'/Billing/InvoiceStatus.ts';
+        $indexFile = $this->outputDir.'/index.ts';
+
+        $this->assertFileExists($statusFile);
+        $this->assertFileExists($invoiceFile);
+        $this->assertFileExists($indexFile);
+
+        $this->assertStringContainsString('export enum Status', File::get($statusFile));
+        $this->assertStringContainsString('export enum InvoiceStatus', File::get($invoiceFile));
+        $this->assertStringContainsString("export { Status } from './Status';", File::get($indexFile));
+        $this->assertStringContainsString("export { InvoiceStatus } from './Billing/InvoiceStatus';", File::get($indexFile));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add configurable enum exporter command
- publish atlas_enums config and register command via service provider
- cover enum export process with tests
- document enum exporter and Laravel Vue Inertia bridge

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a897df84048325b492432b5f23e4b6