### PR TITLE
feat: add base model service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Monorepo containing the Laravel backend and Vue 3 UI components.
 
 ## Laravel Vue Inertia Bridge
 
-Atlas ships with tooling to bridge Laravel and Vue through Inertia, solving two common pain points:
+Atlas ships with tooling to bridge Laravel and Vue through Inertia, solving three common pain points:
 
 - **DataTables** – build server-driven options for dynamic tables.
 - **Enums** – export PHP enums for type-safe usage in Vue.
+- **Service Layer** – base model service providing CRUD scaffolding.
 
 ## Documentation
 
@@ -16,6 +17,7 @@ Atlas ships with tooling to bridge Laravel and Vue through Inertia, solving two 
 - Laravel
   - [Inertia DataTable Options](docs/laravel/inertia-data-table-options.md)
   - [Enum Exporter](docs/laravel/enum-exporter.md)
+  - [Model Service](docs/laravel/model-service.md)
   - [Support](docs/laravel/support.md)
 - UI
   - [Composables](docs/ui/composables.md)

--- a/docs/laravel/model-service.md
+++ b/docs/laravel/model-service.md
@@ -1,0 +1,56 @@
+# Model Service
+
+A base service class for Eloquent models that provides simple CRUD methods.
+Consumers set the model class and may extend or override the methods as needed.
+It also offers helpers for building filtered queries and returning paginated
+results that play nicely with our [Inertia data table options](./inertia-data-table-options.md).
+
+```php
+use Atlas\Laravel\Services\ModelService;
+use App\Models\User;
+
+class UserService extends ModelService
+{
+    protected string $model = User::class;
+}
+```
+
+```php
+$service = new UserService();
+$user = $service->create(['name' => 'Terry']);
+$service->update($user, ['name' => 'Taylor']);
+$service->listPaginated(15, [
+    'search' => 'tay',
+    'sortField' => 'name',
+    'sortOrder' => -1,
+]);
+$service->delete($user);
+```
+
+## Customizing Queries
+
+Override `buildQuery` in your service to push filter or search options into
+the query builder. These options line up with the array returned from the
+Inertia data table helpers, so the controller can simply forward them to the
+service.
+
+```php
+use Illuminate\Database\Eloquent\Builder;
+
+class UserService extends ModelService
+{
+    protected string $model = User::class;
+
+    public function buildQuery(array $options = []): Builder
+    {
+        return parent::buildQuery($options)
+            ->when($options['search'] ?? false, function ($q, $search) {
+                $q->where('name', 'like', "%{$search}%")
+                    ->orWhere('email', 'like', "%{$search}%");
+            })
+            ->when($options['filters']['user_id'] ?? null, function ($q, $userId) {
+                $q->where('id', $userId);
+            });
+    }
+}
+```

--- a/laravel/src/Services/ModelService.php
+++ b/laravel/src/Services/ModelService.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Atlas\Laravel\Services;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+/**
+ * Base service for Eloquent models providing simple CRUD methods.
+ *
+ * Extend this service and set the model class on the consumer side:
+ *
+ * ```php
+ * class UserService extends ModelService
+ * {
+ *     protected string $model = User::class;
+ * }
+ * ```
+ */
+abstract class ModelService
+{
+    /**
+     * The model class managed by the service.
+     */
+    protected string $model;
+
+    /**
+     * Get a new query builder for the model.
+     */
+    public function query(): Builder
+    {
+        return ($this->model)::query();
+    }
+
+    /**
+     * Build a base query for the model. Override to apply filters.
+     */
+    public function buildQuery(array $options = []): Builder
+    {
+        return $this->query();
+    }
+
+    /**
+     * Retrieve all models.
+     */
+    public function list(array $columns = ['*'], array $options = []): Collection
+    {
+        return $this->buildQuery($options)->get($columns);
+    }
+
+    /**
+     * Retrieve a paginated list of models.
+     */
+    public function listPaginated(int $perPage = 15, array $options = []): LengthAwarePaginator
+    {
+        return $this->buildQuery($options)
+            ->when($options['sortField'] ?? false, function ($q) use ($options) {
+                $direction = ($options['sortOrder'] ?? 1) === 1 ? 'asc' : 'desc';
+                return $q->orderBy($options['sortField'], $direction);
+            })
+            ->paginate($perPage)
+            ->withQueryString();
+    }
+
+    /**
+     * Find a model by primary key.
+     */
+    public function find(int|string $id): ?Model
+    {
+        return $this->query()->find($id);
+    }
+
+    /**
+     * Create a new model instance.
+     */
+    public function create(array $data): Model
+    {
+        return $this->query()->create($data);
+    }
+
+    /**
+     * Update the given model instance.
+     */
+    public function update(Model $model, array $data): Model
+    {
+        $model->update($data);
+
+        return $model;
+    }
+
+    /**
+     * Delete the given model instance.
+     */
+    public function delete(Model $model): bool
+    {
+        return (bool) $model->delete();
+    }
+}

--- a/laravel/tests/Services/ModelServiceTest.php
+++ b/laravel/tests/Services/ModelServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Atlas\Laravel\Tests\Services;
+
+use Atlas\Laravel\Services\ModelService;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Orchestra\Testbench\TestCase;
+
+class ModelServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('widgets', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function test_performs_basic_crud_operations(): void
+    {
+        $service = new class extends ModelService {
+            protected string $model = Widget::class;
+        };
+
+        $widget = $service->create(['name' => 'Alpha']);
+        $this->assertSame('Alpha', $widget->name);
+        $this->assertCount(1, $service->list());
+
+        $found = $service->find($widget->id);
+        $this->assertSame('Alpha', $found?->name);
+
+        $service->update($widget, ['name' => 'Beta']);
+        $this->assertSame('Beta', $service->find($widget->id)?->name);
+
+        $service->delete($widget);
+        $this->assertNull($service->find($widget->id));
+    }
+
+    public function test_list_paginated_and_build_query(): void
+    {
+        $service = new class extends ModelService {
+            protected string $model = Widget::class;
+
+            public function buildQuery(array $options = []): Builder
+            {
+                return parent::buildQuery($options)
+                    ->when($options['filters']['name'] ?? null, function ($q, $name) {
+                        $q->where('name', $name);
+                    })
+                    ->when($options['search'] ?? false, function ($q, $search) {
+                        $q->where('name', 'like', "%{$search}%");
+                    });
+            }
+        };
+
+        $service->create(['name' => 'Alpha']);
+        $service->create(['name' => 'Beta']);
+        $service->create(['name' => 'Gamma']);
+
+        $page = $service->listPaginated(2, [
+            'search' => 'a',
+            'sortField' => 'name',
+            'sortOrder' => -1,
+        ]);
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $page);
+        $this->assertSame(3, $page->total());
+        $this->assertSame(['Gamma', 'Beta'], $page->pluck('name')->all());
+
+        $filtered = $service->listPaginated(15, [
+            'filters' => ['name' => 'Alpha'],
+        ]);
+
+        $this->assertSame(1, $filtered->total());
+        $this->assertSame('Alpha', $filtered->first()->name);
+    }
+}
+
+class Widget extends Model
+{
+    protected $guarded = [];
+
+    protected $table = 'widgets';
+}


### PR DESCRIPTION
## Summary
- extend ModelService with buildQuery and listPaginated for sortable paginated results
- document datatable integration and query customization example
- cover listPaginated and buildQuery in tests

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a89eef6d6083259059df9f484a0c45