### PR TITLE
docs: expand Model Service docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Atlas ships with tooling to bridge Laravel and Vue through Inertia, solving thre
 
 - **DataTables** – build server-driven options for dynamic tables.
 - **Enums** – export PHP enums for type-safe usage in Vue.
-- **Service Layer** – base model service providing CRUD scaffolding.
+- **Model Service** – base model service providing CRUD scaffolding.
 
 ## Documentation
 

--- a/docs/laravel/model-service.md
+++ b/docs/laravel/model-service.md
@@ -42,19 +42,18 @@ $service->delete($user);
 
 ## Configuring the Service
 
-You may override `configure` to prepare the service for different contexts.
-
-### Static configuration
+Set the model class on the consumer side. For simple cases you can assign it
+directly on the service:
 
 ```php
 class UserService extends ModelService
 {
-    protected function configure(): void
-    {
-        $this->model = User::class;
-    }
+    protected string $model = User::class;
 }
 ```
+
+For more dynamic scenarios, assign the model in your own constructor or other
+initializer.
 
 ### Contextual configuration
 
@@ -64,11 +63,6 @@ use Illuminate\Database\Eloquent\Builder;
 class TeamUserService extends ModelService
 {
     public function __construct(protected int $teamId)
-    {
-        $this->configure();
-    }
-
-    protected function configure(): void
     {
         $this->model = User::class;
     }
@@ -87,15 +81,12 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 class SortedUserService extends ModelService
 {
+    protected string $model = User::class;
+
     protected array $defaults = [
         'sortField' => 'name',
         'sortOrder' => 1,
     ];
-
-    protected function configure(): void
-    {
-        $this->model = User::class;
-    }
 
     public function listPaginated(int $perPage = 15, array $options = []): LengthAwarePaginator
     {

--- a/docs/laravel/model-service.md
+++ b/docs/laravel/model-service.md
@@ -27,6 +27,85 @@ $service->listPaginated(15, [
 $service->delete($user);
 ```
 
+## Available Methods
+
+`ModelService` ships with a handful of helpers for common CRUD work:
+
+- `query()` – get a new query builder for the model.
+- `buildQuery(array $options = [])` – base query method you can extend.
+- `list(array $columns = ['*'], array $options = [])` – retrieve all models.
+- `listPaginated(int $perPage = 15, array $options = [])` – retrieve a paginated list.
+- `find(int|string $id)` – locate a model by its primary key.
+- `create(array $data)` – persist a new model.
+- `update(Model $model, array $data)` – update an existing model.
+- `delete(Model $model)` – remove a model from storage.
+
+## Configuring the Service
+
+You may override `configure` to prepare the service for different contexts.
+
+### Static configuration
+
+```php
+class UserService extends ModelService
+{
+    protected function configure(): void
+    {
+        $this->model = User::class;
+    }
+}
+```
+
+### Contextual configuration
+
+```php
+use Illuminate\Database\Eloquent\Builder;
+
+class TeamUserService extends ModelService
+{
+    public function __construct(protected int $teamId)
+    {
+        $this->configure();
+    }
+
+    protected function configure(): void
+    {
+        $this->model = User::class;
+    }
+
+    public function buildQuery(array $options = []): Builder
+    {
+        return parent::buildQuery($options)->where('team_id', $this->teamId);
+    }
+}
+```
+
+### Setting defaults
+
+```php
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+class SortedUserService extends ModelService
+{
+    protected array $defaults = [
+        'sortField' => 'name',
+        'sortOrder' => 1,
+    ];
+
+    protected function configure(): void
+    {
+        $this->model = User::class;
+    }
+
+    public function listPaginated(int $perPage = 15, array $options = []): LengthAwarePaginator
+    {
+        $options = array_merge($this->defaults, $options);
+
+        return parent::listPaginated($perPage, $options);
+    }
+}
+```
+
 ## Customizing Queries
 
 Override `buildQuery` in your service to push filter or search options into


### PR DESCRIPTION
## Summary
- rename service layer mention in the README to "Model Service"
- document built-in Model Service methods and configuration examples

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8a41e7cdc8325b5123982dd7f78ae