### PR TITLE
docs: link component API references

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -28,6 +28,10 @@ import { Button } from '@atlas/ui';
 <Button>Click me</Button>
 ```
 
+##### API
+
+Refer to the [PrimeVue Button API](https://primevue.org/button/#api) for available props and events.
+
 ### Form Elements
 
 #### InputText
@@ -39,6 +43,10 @@ import { InputText } from '@atlas/ui';
 <InputText v-model="value" />
 ```
 
+##### API
+
+See the [PrimeVue InputText API](https://primevue.org/inputtext/#api).
+
 #### InputNumber
 ```ts
 import { InputNumber } from '@atlas/ui';
@@ -47,6 +55,10 @@ import { InputNumber } from '@atlas/ui';
 ```vue
 <InputNumber v-model="value" />
 ```
+
+##### API
+
+See the [PrimeVue InputNumber API](https://primevue.org/inputnumber/#api).
 
 #### InputMask
 ```ts
@@ -57,6 +69,10 @@ import { InputMask } from '@atlas/ui';
 <InputMask mask="99/99/9999" v-model="value" />
 ```
 
+##### API
+
+Refer to the [PrimeVue InputMask API](https://primevue.org/inputmask/#api).
+
 #### Select
 ```ts
 import { Select } from '@atlas/ui';
@@ -65,6 +81,10 @@ import { Select } from '@atlas/ui';
 ```vue
 <Select :options="options" v-model="selected" />
 ```
+
+##### API
+
+See the [PrimeVue Select API](https://primevue.org/select/#api).
 
 #### Textarea
 ```ts
@@ -75,6 +95,10 @@ import { Textarea } from '@atlas/ui';
 <Textarea v-model="value" />
 ```
 
+##### API
+
+Refer to the [PrimeVue Textarea API](https://primevue.org/textarea/#api).
+
 #### Checkbox
 ```ts
 import { Checkbox } from '@atlas/ui';
@@ -83,6 +107,10 @@ import { Checkbox } from '@atlas/ui';
 ```vue
 <Checkbox v-model="checked" />
 ```
+
+##### API
+
+See the [PrimeVue Checkbox API](https://primevue.org/checkbox/#api).
 
 ### Layout
 
@@ -94,3 +122,7 @@ import { Card } from '@atlas/ui';
 ```vue
 <Card title="Title">Content</Card>
 ```
+
+##### API
+
+Refer to the [PrimeVue Card API](https://primevue.org/card/#api).


### PR DESCRIPTION
## Summary
- document API links for Button, InputText, InputNumber, InputMask, Select, Textarea, Checkbox, and Card components

## Testing
- `npm test`
- `composer test` (fails: vendor/bin/phpunit: not found)


------
https://chatgpt.com/codex/tasks/task_b_68a8c809cf2c8325a3c555be5fd68f9c