### PR TITLE
docs: clarify package purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Atlas
 
-Monorepo containing the Laravel backend and Vue 3 UI components.
+Atlas is designed for apps built with [Laravel](https://laravel.com), [Vue](https://vuejs.org), and [Inertia.js](https://inertiajs.com). It bundles a Laravel backend with a library of Vue 3 components optimized for Inertia-driven dashboards. Those Vue components can also be used in standalone Vue applications without Laravel or Inertia.
+
+This package bridges common pain points when maintaining projects and helps you avoid reinventing the wheel. It strives to provide guidelines and the basic essentials for building web-based applications—mostly around dashboards or admin systems—but it can be used for any web-based project.
 
 ## Laravel Vue Inertia Bridge
 


### PR DESCRIPTION
## Summary
- clarify Atlas' purpose and standalone Vue component usage in README

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8ca00cdd88325bef4aa2938ee6bb7