### PR TITLE
docs: split README into Laravel and Vue sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,35 @@
 # Atlas
 
-Atlas is designed for apps built with [Laravel](https://laravel.com), [Vue](https://vuejs.org), and [Inertia.js](https://inertiajs.com). It bundles a Laravel backend with a library of Vue 3 components optimized for Inertia-driven dashboards. Those Vue components can also be used in standalone Vue applications without Laravel or Inertia.
+Atlas is designed for apps built with [Laravel](https://laravel.com), [Vue](https://vuejs.org), and [Inertia.js](https://inertiajs.com). It bundles a Laravel backend with a library of Vue components to help teams spin up dashboards quickly. Both sides can be used together or independently.
 
-This package bridges common pain points when maintaining projects and helps you avoid reinventing the wheel. It strives to provide guidelines and the basic essentials for building web-based applications—mostly around dashboards or admin systems—but it can be used for any web-based project.
+Atlas focuses on eliminating the repeated setup that comes with every new project. It delivers guidelines and battle-tested building blocks so you can ship web-based applications faster, whether you're working on a full-blown admin system or a small dashboard.
 
-## Laravel Vue Inertia Bridge
+## Laravel
 
-Atlas ships with tooling to bridge Laravel and Vue through Inertia, solving three common pain points:
+Our Laravel package handles the backend foundation and Inertia bridge. It includes tooling for:
 
 - **DataTables** – build server-driven options for dynamic tables.
 - **Enums** – export PHP enums for type-safe usage in Vue.
 - **Model Service** – base model service providing CRUD scaffolding.
 
-## Documentation
+**Documentation**
 
 - [Backend Guide](docs/backend-guide.md)
+- [Inertia DataTable Options](docs/laravel/inertia-data-table-options.md)
+- [Enum Exporter](docs/laravel/enum-exporter.md)
+- [Model Service](docs/laravel/model-service.md)
+- [Support](docs/laravel/support.md)
+
+## Vue
+
+The front end centers on a reusable UI library powered by **Vue 3**, **PrimeVue 4**, and **Tailwind CSS 4**. It pairs naturally with Laravel through Inertia but can also slot into any Vue 3 application.
+
+**Documentation**
+
 - [Frontend Guide](docs/frontend-guide.md)
-- Laravel
-  - [Inertia DataTable Options](docs/laravel/inertia-data-table-options.md)
-  - [Enum Exporter](docs/laravel/enum-exporter.md)
-  - [Model Service](docs/laravel/model-service.md)
-  - [Support](docs/laravel/support.md)
-- UI
-  - [Components](docs/ui.md)
-  - [Composables](docs/ui/composables.md)
-  - [Utils](docs/ui/utils.md)
+- [Components](docs/ui.md)
+- [Composables](docs/ui/composables.md)
+- [Utils](docs/ui/utils.md)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- clarify Atlas' purpose and focus on reusable building blocks
- reorganize documentation into dedicated **Laravel** and **Vue** sections
- highlight Vue stack: Vue 3, PrimeVue 4, Tailwind CSS 4

## Testing
- `composer test` (in `laravel/`)
- `npm test` (in `ui/`)


------
https://chatgpt.com/codex/tasks/task_b_68a8d37fe8948325932e30b11c981905