### PR TITLE
feat(ui): add chip and divider components

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -32,6 +32,9 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Checkbox](#checkbox)
 - [Layout](#layout)
   - [Card](#card)
+  - [Divider](#divider)
+- [Data Display](#data-display)
+  - [Chip](#chip)
 - [Feedback](#feedback)
   - [Alert](#alert)
 
@@ -144,6 +147,34 @@ import { Card } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue Card API](https://primevue.org/card/#api).
+
+#### Divider
+```ts
+import { Divider } from '@atlas/ui';
+```
+
+```vue
+<Divider />
+```
+
+##### API
+
+Refer to the [PrimeVue Divider API](https://primevue.org/divider/#api).
+
+### Data Display
+
+#### Chip
+```ts
+import { Chip } from '@atlas/ui';
+```
+
+```vue
+<Chip label="Label" />
+```
+
+##### API
+
+Refer to the [PrimeVue Chip API](https://primevue.org/chip/#api).
 
 ### Feedback
 

--- a/ui/src/components/Chip.vue
+++ b/ui/src/components/Chip.vue
@@ -1,0 +1,47 @@
+<template>
+    <Chip
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template #removeicon="{ removeCallback, keydownCallback }">
+            <TimesCircleIcon
+                class="cursor-pointer text-base w-4 h-4 rounded-full text-surface-800 dark:text-surface-0 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-primary"
+                @click="removeCallback"
+                @keydown="keydownCallback"
+            />
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Chip>
+</template>
+
+<script setup lang="ts">
+import TimesCircleIcon from '@primevue/icons/timescircle';
+import Chip, { type ChipPassThroughOptions, type ChipProps } from 'primevue/chip';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, mergePT } from '../utils';
+
+interface Props extends /* @vue-ignore */ ChipProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<ChipPassThroughOptions>({
+    root: `inline-flex items-center rounded-2xl gap-2 px-3 py-2
+        bg-surface-100 dark:bg-surface-800
+        text-surface-800 dark:text-surface-0
+        has-[img]:pt-1 has-[img]:pb-1
+        p-removable:pe-2`,
+    image: `rounded-full w-8 h-8 -ms-2`,
+    icon: `text-surface-800 dark:text-surface-0 text-base w-4 h-4`
+});
+
+const mergedPt = computed(() => mergePT(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/Divider.vue
+++ b/ui/src/components/Divider.vue
@@ -1,0 +1,41 @@
+<template>
+    <Divider
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Divider>
+</template>
+
+<script setup lang="ts">
+import Divider, { type DividerPassThroughOptions, type DividerProps } from 'primevue/divider';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, mergePT } from '../utils';
+
+interface Props extends /* @vue-ignore */ DividerProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<DividerPassThroughOptions>({
+    root: `p-horizontal:flex p-horizontal:w-full p-horizontal:relative p-horizontal:items-center p-horizontal:my-4 p-horizontal:mx-0 p-horizontal:py-0 p-horizontal:px-4
+        p-horizontal:before:absolute p-horizontal:before:block p-horizontal:before:top-1/2 p-horizontal:before:start-0 p-horizontal:before:w-full
+        p-horizontal:before:border-t p-horizontal:before:border-surface-200 dark:p-horizontal:before:border-surface-700
+        p-vertical:min-h-full p-vertical:flex p-vertical:relative p-vertical:justify-center p-vertical:my-0 p-vertical:mx-4 p-vertical:py-2 p-vertical:px-0
+        p-vertical:before:absolute p-vertical:before:block p-vertical:before:top-0 p-vertical:before:start-1/2 p-vertical:before:h-full
+        p-vertical:before:border-s p-vertical:before:border-surface-200 dark:p-vertical:before:border-surface-700
+        p-solid:before:border-solid p-dashed:before:border-dashed p-dotted:before:border-dotted`,
+    content: `z-10 bg-surface-0 dark:bg-surface-900 text-surface-700 dark:text-surface-0
+        p-horizontal:py-0 p-horizontal:px-2 p-vertical:py-2 p-vertical:px-0`
+});
+
+const mergedPt = computed(() => mergePT(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -7,3 +7,5 @@ export { default as InputText } from './InputText.vue';
 export { default as Alert } from './Alert.vue';
 export { default as Select } from './Select.vue';
 export { default as Textarea } from './Textarea.vue';
+export { default as Chip } from './Chip.vue';
+export { default as Divider } from './Divider.vue';


### PR DESCRIPTION
## Summary
- add Chip and Divider components with passthrough support
- document Chip and Divider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8d43b3a2c8325b6e96dfd9af280bf