### PR TITLE
feat(ui): add ScrollFrame component

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -142,12 +142,26 @@ import { ScrollFrame } from '@atlas/ui';
 ```
 
 ```vue
-<ScrollFrame>
-    Content
+<ScrollFrame
+  page
+  scroll-key="settings"
+  :add-offset="16"
+  class="p-4"
+>
+  <!-- scrollable content -->
 </ScrollFrame>
 ```
 
-Provides a scrollable container that fills the viewport and manages scroll locking when used as a page frame.
+Provides a scrollable container sized to the viewport. When `page` is set it locks body scrolling and uses `scroll-key` to preserve position.
+
+##### Props
+
+- `scrollKey` (string | null) – identifier used by the scroll composable to persist position. Defaults to `null`.
+- `page` (boolean) – lock body scroll and treat the frame as a full page. Defaults to `false`.
+- `allowBodyScroll` (boolean) – allow body scroll even when `page` is `true`. Defaults to `false`.
+- `offset` (number | null) – explicit pixel offset for height calculation. Defaults to element top position.
+- `addOffset` (number) – extra pixels subtracted from height. Defaults to `0`.
+- `rootClass` (string) – additional classes for the frame element. Defaults to `overflow-y-auto`.
 
 #### Card
 ```ts

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -31,6 +31,7 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Textarea](#textarea)
   - [Checkbox](#checkbox)
 - [Layout](#layout)
+  - [ScrollFrame](#scrollframe)
   - [Card](#card)
   - [Divider](#divider)
 - [Data Display](#data-display)
@@ -134,6 +135,19 @@ import { Checkbox } from '@atlas/ui';
 See the [PrimeVue Checkbox API](https://primevue.org/checkbox/#api).
 
 ### Layout
+
+#### ScrollFrame
+```ts
+import { ScrollFrame } from '@atlas/ui';
+```
+
+```vue
+<ScrollFrame>
+    Content
+</ScrollFrame>
+```
+
+Provides a scrollable container that fills the viewport and manages scroll locking when used as a page frame.
 
 #### Card
 ```ts

--- a/ui/src/components/ScrollFrame.vue
+++ b/ui/src/components/ScrollFrame.vue
@@ -1,0 +1,79 @@
+<template>
+    <div
+        ref="frame"
+        class="frame-scroll"
+        :class="rootClass"
+        :style="{ height: `calc(100vh - ${dynamicHeight} - ${addOffset}px)` }"
+    >
+        <slot />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
+import { useScroll } from '../composables/useScroll';
+
+interface Props {
+    scrollKey?: string | null;
+    page?: boolean;
+    allowBodyScroll?: boolean;
+    offset?: number | null;
+    addOffset?: number;
+    rootClass?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    scrollKey: null,
+    page: false,
+    allowBodyScroll: false,
+    offset: null,
+    addOffset: 0,
+    rootClass: 'overflow-y-auto',
+});
+
+const frame = ref<HTMLElement | null>(null);
+const dynamicHeight = ref('0px');
+
+const { bindScrollHandler, lockScroll, unlockScroll } = useScroll(
+    props.scrollKey !== null ? props.scrollKey : props.page ? 'page' : Symbol()
+);
+
+const { add, remove } = bindScrollHandler(frame);
+
+const updateHeight = () => {
+    const offsetValue = props.offset !== null ? props.offset : calculateOffsets();
+    dynamicHeight.value = `${offsetValue}px`;
+};
+
+const calculateOffsets = () => {
+    const frameElement = frame.value;
+    if (!frameElement) return 0;
+
+    const { top } = frameElement.getBoundingClientRect();
+    return Math.round(top);
+};
+
+onMounted(() => {
+    add();
+    if (props.page && !props.allowBodyScroll) lockScroll();
+    nextTick(() => {
+        updateHeight();
+    });
+});
+
+onBeforeUnmount(() => {
+    remove();
+    if (props.page && !props.allowBodyScroll) unlockScroll();
+});
+
+watch(() => props.offset, updateHeight);
+
+watch(
+    () => props.allowBodyScroll,
+    () => {
+        if (!props.page) return;
+        props.allowBodyScroll ? unlockScroll() : lockScroll();
+    }
+);
+</script>
+

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -9,3 +9,4 @@ export { default as Select } from './Select.vue';
 export { default as Textarea } from './Textarea.vue';
 export { default as Chip } from './Chip.vue';
 export { default as Divider } from './Divider.vue';
+export { default as ScrollFrame } from './ScrollFrame.vue';


### PR DESCRIPTION
## Summary
- add ScrollFrame component for viewport-based scrolling and optional body lock
- document ScrollFrame usage in UI guide

## Testing
- `npm test` *(fails: expected 'p-small:!px-[0.625rem]')*


------
https://chatgpt.com/codex/tasks/task_b_68a8d65de25c8325bbbf9ff96418854e