### PR TITLE
docs: clarify UI doc API links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ All contributions must follow the architecture and coding conventions outlined i
 - UI docs:
   - [Composables](docs/ui/composables.md)
   - [Utils](docs/ui/utils.md)
+- When updating UI documentation that discusses a component's API, link to the corresponding PrimeVue API. If PrimeVue lacks an API page, document the component's API details so consumers understand how to use it.
 
 ## Testing
 - Run front-end tests with `npm test` inside `ui/`.


### PR DESCRIPTION
## Summary
- specify linking to PrimeVue API in UI docs or describing component API when no upstream docs exist

## Testing
- `npm test` *(fails: expected button padding classes to contain p-small)*
- `composer test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8d768eb1c8325bb215e7fe7d8eba0