### PR TITLE
chore(playground): remove postcss

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -15,9 +15,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",
-    "autoprefixer": "^10.4.21",
-    "@tailwindcss/postcss": "^4.1.4",
-    "postcss": "^8.5.6",
+    "@tailwindcss/vite": "^4.1.4",
     "tailwindcss": "^4.1.4",
     "tailwindcss-primeui": "^0.6.1",
     "@tailwindcss/typography": "^0.5.16",

--- a/playground/postcss.config.js
+++ b/playground/postcss.config.js
@@ -1,9 +1,0 @@
-import tailwindcss from '@tailwindcss/postcss'
-import autoprefixer from 'autoprefixer'
-
-export default {
-  plugins: [
-    tailwindcss(),
-    autoprefixer(),
-  ],
-}

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), tailwindcss()],
   resolve: {
     alias: {
       '@ui': path.resolve(__dirname, '../ui/src')


### PR DESCRIPTION
## Summary
- drop PostCSS configuration in the playground
- configure Vite with `@tailwindcss/vite`

## Testing
- `cd ui && npm test` *(fails: expected 'inline-flex self-start cursor-pointer…' to contain 'p-small:!px-[0.625rem]')*
- `cd laravel && composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a8d8c458408325a7efc114bea0a760