### PR TITLE
feat(ui): add accordion components

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -32,6 +32,7 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Checkbox](#checkbox)
 - [Layout](#layout)
   - [ScrollFrame](#scrollframe)
+  - [Accordion](#accordion)
   - [Card](#card)
   - [Divider](#divider)
 - [Data Display](#data-display)
@@ -162,6 +163,24 @@ Provides a scrollable container sized to the viewport. When `page` is set it loc
 - `offset` (number | null) – explicit pixel offset for height calculation. Defaults to element top position.
 - `addOffset` (number) – extra pixels subtracted from height. Defaults to `0`.
 - `rootClass` (string) – additional classes for the frame element. Defaults to `overflow-y-auto`.
+
+#### Accordion
+```ts
+import { Accordion, AccordionPanel, AccordionHeader, AccordionContent } from '@atlas/ui';
+```
+
+```vue
+<Accordion>
+  <AccordionPanel value="0">
+    <AccordionHeader>Header</AccordionHeader>
+    <AccordionContent>Content</AccordionContent>
+  </AccordionPanel>
+</Accordion>
+```
+
+##### API
+
+Refer to the [PrimeVue Accordion API](https://primevue.org/accordion/#api).
 
 #### Card
 ```ts

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -8,6 +8,10 @@ import InputNumber from '@ui/components/InputNumber.vue'
 import InputText from '@ui/components/InputText.vue'
 import Select from '@ui/components/Select.vue'
 import Textarea from '@ui/components/Textarea.vue'
+import Accordion from '@ui/components/Accordion.vue'
+import AccordionPanel from '@ui/components/AccordionPanel.vue'
+import AccordionHeader from '@ui/components/AccordionHeader.vue'
+import AccordionContent from '@ui/components/AccordionContent.vue'
 
 const text = ref('')
 const number = ref()
@@ -19,6 +23,7 @@ const options = [
 ]
 const agree = ref(false)
 const message = ref('')
+const active = ref('0')
 </script>
 
 <template>
@@ -50,6 +55,24 @@ const message = ref('')
           <p>This is a simple card showcasing how content is displayed inside.</p>
         </template>
       </Card>
+    </section>
+
+    <section>
+      <h2 class="mb-4 text-xl font-semibold">Accordion</h2>
+      <Accordion v-model:value="active">
+        <AccordionPanel value="0">
+          <AccordionHeader>Header I</AccordionHeader>
+          <AccordionContent>
+            <p class="m-0">Content I</p>
+          </AccordionContent>
+        </AccordionPanel>
+        <AccordionPanel value="1">
+          <AccordionHeader>Header II</AccordionHeader>
+          <AccordionContent>
+            <p class="m-0">Content II</p>
+          </AccordionContent>
+        </AccordionPanel>
+      </Accordion>
     </section>
 
     <section>

--- a/ui/src/components/Accordion.vue
+++ b/ui/src/components/Accordion.vue
@@ -1,0 +1,33 @@
+<template>
+    <Accordion
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Accordion>
+</template>
+
+<script setup lang="ts">
+import Accordion, { type AccordionPassThroughOptions, type AccordionProps } from 'primevue/accordion';
+import { ref, useAttrs, computed } from 'vue';
+import { ptMerge, ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ AccordionProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<AccordionPassThroughOptions>({
+    root: ``
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/AccordionContent.vue
+++ b/ui/src/components/AccordionContent.vue
@@ -1,0 +1,40 @@
+<template>
+    <AccordionContent
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <slot></slot>
+    </AccordionContent>
+</template>
+
+<script setup lang="ts">
+import AccordionContent, { type AccordionContentPassThroughOptions, type AccordionContentProps } from 'primevue/accordioncontent';
+import { ref, useAttrs, computed } from 'vue';
+import { ptMerge, ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ AccordionContentProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<AccordionContentPassThroughOptions>({
+    root: `flex flex-col`,
+    content: `text-surface-700 dark:text-surface-0 pt-0 px-[1.125rem] px-6 pb-[1.125rem] text-base`,
+    transition: {
+        enterFromClass: 'max-h-0',
+        enterActiveClass: 'overflow-hidden transition-[max-height] duration-1000 ease-[cubic-bezier(0.42,0,0.58,1)]',
+        enterToClass: 'max-h-[1000px]',
+        leaveFromClass: 'max-h-[1000px]',
+        leaveActiveClass: 'overflow-hidden transition-[max-height] duration-[450ms] ease-[cubic-bezier(0,1,0,1)]',
+        leaveToClass: 'max-h-0'
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/AccordionHeader.vue
+++ b/ui/src/components/AccordionHeader.vue
@@ -1,0 +1,43 @@
+<template>
+    <AccordionHeader
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template #toggleicon="{ active }">
+            <ChevronDownIcon v-if="active" />
+            <ChevronUpIcon v-else />
+        </template>
+        <slot></slot>
+    </AccordionHeader>
+</template>
+
+<script setup lang="ts">
+import ChevronDownIcon from '@primevue/icons/chevrondown';
+import ChevronUpIcon from '@primevue/icons/chevronup';
+import AccordionHeader, { type AccordionHeaderPassThroughOptions, type AccordionHeaderProps } from 'primevue/accordionheader';
+import { ref, useAttrs, computed } from 'vue';
+import { ptMerge, ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ AccordionHeaderProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<AccordionHeaderPassThroughOptions>({
+    root: `cursor-pointer disabled:pointer-events-none disabled:opacity-60 flex items-center justify-between p-[1.125rem] px-6 py-4 font-semibold
+        text-surface-500 dark:text-surface-400
+        hover:text-surface-700 dark:hover:text-surface-0
+        hover:bg-surface-100 dark:hover:bg-surface-700
+        p-active:text-surface-800 dark:p-active:text-surface-0
+        transition-colors duration-200
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-1px] focus-visible:outline-primary`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/AccordionPanel.vue
+++ b/ui/src/components/AccordionPanel.vue
@@ -1,0 +1,31 @@
+<template>
+    <AccordionPanel
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <slot></slot>
+    </AccordionPanel>
+</template>
+
+<script setup lang="ts">
+import AccordionPanel, { type AccordionPanelPassThroughOptions, type AccordionPanelProps } from 'primevue/accordionpanel';
+import { ref, useAttrs, computed } from 'vue';
+import { ptMerge, ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ AccordionPanelProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<AccordionPanelPassThroughOptions>({
+    root: `flex flex-col border-b border-surface-200 dark:border-surface-700`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -10,3 +10,7 @@ export { default as Textarea } from './Textarea.vue';
 export { default as Chip } from './Chip.vue';
 export { default as Divider } from './Divider.vue';
 export { default as ScrollFrame } from './ScrollFrame.vue';
+export { default as Accordion } from './Accordion.vue';
+export { default as AccordionContent } from './AccordionContent.vue';
+export { default as AccordionHeader } from './AccordionHeader.vue';
+export { default as AccordionPanel } from './AccordionPanel.vue';


### PR DESCRIPTION
## Summary
- add Accordion, AccordionContent, AccordionHeader, and AccordionPanel components with passthrough support
- document Accordion usage and link to PrimeVue API
- showcase Accordion in playground

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8e183ddf483259e844b83ebe6007c