### PR TITLE
feat(ui): add avatar components

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -36,6 +36,8 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Card](#card)
   - [Divider](#divider)
 - [Data Display](#data-display)
+  - [Avatar](#avatar)
+  - [AvatarGroup](#avatargroup)
   - [Chip](#chip)
 - [Feedback](#feedback)
   - [Alert](#alert)
@@ -209,6 +211,35 @@ import { Divider } from '@atlas/ui';
 Refer to the [PrimeVue Divider API](https://primevue.org/divider/#api).
 
 ### Data Display
+
+#### Avatar
+```ts
+import { Avatar } from '@atlas/ui';
+```
+
+```vue
+<Avatar label="AB" />
+```
+
+##### API
+
+Refer to the [PrimeVue Avatar API](https://primevue.org/avatar/#api).
+
+#### AvatarGroup
+```ts
+import { AvatarGroup, Avatar } from '@atlas/ui';
+```
+
+```vue
+<AvatarGroup>
+  <Avatar label="AB" />
+  <Avatar label="CD" />
+</AvatarGroup>
+```
+
+##### API
+
+Refer to the [PrimeVue AvatarGroup API](https://primevue.org/avatargroup/#api).
 
 #### Chip
 ```ts

--- a/ui/src/components/Avatar.vue
+++ b/ui/src/components/Avatar.vue
@@ -1,0 +1,42 @@
+<template>
+    <Avatar
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Avatar>
+</template>
+
+<script setup lang="ts">
+import Avatar, { type AvatarPassThroughOptions, type AvatarProps } from 'primevue/avatar';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ AvatarProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<AvatarPassThroughOptions>({
+    root: `inline-flex items-center justify-center
+        w-8 h-8 text-base rounded-md
+        bg-surface-200 dark:bg-surface-700
+        has-[img]:bg-transparent
+        p-circle:rounded-full
+        p-large:w-12 p-large:h-12 p-large:text-2xl
+        p-xlarge:w-16 p-xlarge:h-16 p-xlarge:text-[2rem]`,
+    label: ``,
+    icon: `text-base p-large:text-2xl p-xlarge:text-[2rem]`,
+    image: `p-circle:rounded-full w-full h-full`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/AvatarGroup.vue
+++ b/ui/src/components/AvatarGroup.vue
@@ -1,0 +1,33 @@
+<template>
+    <AvatarGroup
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </AvatarGroup>
+</template>
+
+<script setup lang="ts">
+import AvatarGroup, { type AvatarGroupPassThroughOptions, type AvatarGroupProps } from 'primevue/avatargroup';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ AvatarGroupProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<AvatarGroupPassThroughOptions>({
+    root: `flex items-center *:border-2 *:border-surface-200 dark:*:border-surface-700 *:-ms-3`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -7,6 +7,8 @@ export { default as InputText } from './InputText.vue';
 export { default as Alert } from './Alert.vue';
 export { default as Select } from './Select.vue';
 export { default as Textarea } from './Textarea.vue';
+export { default as Avatar } from './Avatar.vue';
+export { default as AvatarGroup } from './AvatarGroup.vue';
 export { default as Chip } from './Chip.vue';
 export { default as Divider } from './Divider.vue';
 export { default as ScrollFrame } from './ScrollFrame.vue';


### PR DESCRIPTION
## Summary
- add Avatar and AvatarGroup components with default Tailwind themes
- document Avatar and AvatarGroup usage in UI docs
- ensure Avatar components merge passthrough overrides

## Testing
- `cd ui && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8e2d18bb08325a092ef2e49c3c7a0