### PR TITLE
feat: extract parseUtcDate utility

### DIFF
--- a/ui/src/utils/format/formatDate.ts
+++ b/ui/src/utils/format/formatDate.ts
@@ -1,3 +1,5 @@
+import { parseUtcDate } from './parseUtcDate';
+
 /**
  * Converts a UTC datetime (string or Date) to a localized date string.
  * @param utcDatetime - A UTC ISO date string or Date object
@@ -12,14 +14,9 @@ export const formatDate = (
 ): string => {
     if (!utcDatetime) return '';
 
-    const date =
-        utcDatetime instanceof Date
-            ? utcDatetime
-            : typeof utcDatetime === 'string'
-                ? new Date(utcDatetime.endsWith('Z') ? utcDatetime : `${utcDatetime}Z`)
-                : null;
+    const date = parseUtcDate(utcDatetime);
 
-    if (!date || isNaN(date.getTime())) return '';
+    if (!date) return '';
 
     return date.toLocaleDateString(locale, { timeZone: userTimezone });
 };

--- a/ui/src/utils/format/formatDatetime.ts
+++ b/ui/src/utils/format/formatDatetime.ts
@@ -1,3 +1,5 @@
+import { parseUtcDate } from './parseUtcDate';
+
 /**
  * Converts a UTC datetime string to a localized date + time string (no seconds).
  * @param utcDatetime - The UTC ISO date string
@@ -12,14 +14,9 @@ export const formatDatetime = (
 ): string => {
     if (!utcDatetime) return '';
 
-    const date =
-        utcDatetime instanceof Date
-            ? utcDatetime
-            : typeof utcDatetime === 'string'
-                ? new Date(utcDatetime.endsWith('Z') ? utcDatetime : `${utcDatetime}Z`)
-                : null;
+    const date = parseUtcDate(utcDatetime);
 
-    if (!date || isNaN(date.getTime())) return '';
+    if (!date) return '';
 
     return date.toLocaleString(locale, {
         timeZone: userTimezone,

--- a/ui/src/utils/format/index.ts
+++ b/ui/src/utils/format/index.ts
@@ -2,6 +2,7 @@ export * from './formatBytes';
 export * from './formatCurrency';
 export * from './formatDate';
 export * from './formatDatetime';
+export * from './parseUtcDate';
 export * from './formatNumber';
 export * from './formatPercentage';
 export * from './formatSlug';

--- a/ui/src/utils/format/parseUtcDate.ts
+++ b/ui/src/utils/format/parseUtcDate.ts
@@ -1,0 +1,22 @@
+/**
+ * Parses a UTC datetime (string or Date) into a Date object.
+ * Appends a "Z" suffix for strings missing it to ensure UTC interpretation.
+ *
+ * @param utcDate - A UTC ISO date string or Date object
+ * @returns Parsed Date object or null if invalid
+ */
+export const parseUtcDate = (utcDate: string | Date): Date | null => {
+    if (!utcDate) return null;
+
+    const date =
+        utcDate instanceof Date
+            ? utcDate
+            : typeof utcDate === 'string'
+                ? new Date(utcDate.endsWith('Z') ? utcDate : `${utcDate}Z`)
+                : null;
+
+    if (!date || isNaN(date.getTime())) return null;
+
+    return date;
+};
+

--- a/ui/tests/utils/format/parseUtcDate.test.ts
+++ b/ui/tests/utils/format/parseUtcDate.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { parseUtcDate } from '../../../src/utils/format/parseUtcDate';
+
+describe('parseUtcDate', () => {
+    it('should parse an ISO string without Z suffix', () => {
+        const date = parseUtcDate('2023-01-15T14:30:00');
+        expect(date).toBeInstanceOf(Date);
+        expect(date?.toISOString()).toBe('2023-01-15T14:30:00.000Z');
+    });
+
+    it('should parse an ISO string with Z suffix', () => {
+        const date = parseUtcDate('2023-02-20T10:15:00Z');
+        expect(date).toBeInstanceOf(Date);
+        expect(date?.toISOString()).toBe('2023-02-20T10:15:00.000Z');
+    });
+
+    it('should return the same Date instance', () => {
+        const original = new Date('2023-03-10T18:45:00Z');
+        const parsed = parseUtcDate(original);
+        expect(parsed).toBe(original);
+    });
+
+    it('should return null for invalid input', () => {
+        expect(parseUtcDate('not-a-date')).toBeNull();
+    });
+
+    it('should return null for nullish input', () => {
+        expect(parseUtcDate(null as unknown as string)).toBeNull();
+        expect(parseUtcDate(undefined as unknown as string)).toBeNull();
+    });
+});
+


### PR DESCRIPTION
## Summary
- centralize UTC date parsing in new `parseUtcDate` helper
- reuse helper in `formatDate` and `formatDatetime`
- expose helper via utilities index and add unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8e31d1cb88325b4daf995a44b1e34