### PR TITLE
Handle empty currency input in format utility

### DIFF
--- a/ui/src/utils/format/formatCurrency.ts
+++ b/ui/src/utils/format/formatCurrency.ts
@@ -1,17 +1,18 @@
 /**
  * Formats a value into a localized currency string.
- * @param n - The numeric value to format
+ * @param n - The numeric value to format. Empty, null, or undefined values return the `invalid` string.
  * @param decimals - Number of decimal places (default: 2)
  * @param currency - Currency code (e.g. 'USD') (default: 'USD')
  * @param invalid - Return value if n is not numeric (default: 'Invalid')
  * @returns The formatted currency string
  */
 export const formatCurrency = (
-    n: string | number,
+    n: string | number | null | undefined,
     decimals = 2,
     currency = 'USD',
     invalid = 'Invalid'
 ): string => {
+    if (n === '' || n === null || n === undefined) return invalid;
     if (isNaN(Number(n))) return invalid;
     return new Intl.NumberFormat('en-US', {
         style: 'currency',

--- a/ui/tests/utils/format/formatCurrency.test.ts
+++ b/ui/tests/utils/format/formatCurrency.test.ts
@@ -36,8 +36,16 @@ describe('formatCurrency', () => {
         expect(formatCurrency('abc')).toBe('Invalid');
     });
 
+    it('should return "Invalid" for empty string', () => {
+        expect(formatCurrency('')).toBe('Invalid');
+    });
+
     it('should return custom invalid text when specified', () => {
         expect(formatCurrency('abc', 2, 'USD', 'N/A')).toBe('N/A');
+    });
+
+    it('should return custom invalid text for empty string when specified', () => {
+        expect(formatCurrency('', 2, 'USD', 'N/A')).toBe('N/A');
     });
 
     it('should handle NaN input', () => {


### PR DESCRIPTION
## Summary
- handle empty, null, and undefined values in `formatCurrency`
- test `formatCurrency` with empty strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8e8fd9d488325a42981b47bb9e342