### PR TITLE
feat(ui): add Menu, MultiSelect, and AutoComplete components

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -31,6 +31,8 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [InputGroup](#inputgroup)
   - [InputOtp](#inputotp)
   - [Select](#select)
+  - [AutoComplete](#autocomplete)
+  - [MultiSelect](#multiselect)
   - [Textarea](#textarea)
   - [Checkbox](#checkbox)
 - [Layout](#layout)
@@ -43,6 +45,8 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [AvatarGroup](#avatargroup)
   - [Chip](#chip)
   - [Badge](#badge)
+- [Navigation](#navigation)
+  - [Menu](#menu)
 - [Feedback](#feedback)
   - [Alert](#alert)
 
@@ -159,6 +163,32 @@ import { Select } from '@atlas/ui';
 ##### API
 
 See the [PrimeVue Select API](https://primevue.org/select/#api).
+
+#### AutoComplete
+```ts
+import { AutoComplete } from '@atlas/ui';
+```
+
+```vue
+<AutoComplete v-model="value" :suggestions="items" />
+```
+
+##### API
+
+See the [PrimeVue AutoComplete API](https://primevue.org/autocomplete/#api).
+
+#### MultiSelect
+```ts
+import { MultiSelect } from '@atlas/ui';
+```
+
+```vue
+<MultiSelect v-model="selected" :options="options" optionLabel="name" optionValue="value" />
+```
+
+##### API
+
+Refer to the [PrimeVue MultiSelect API](https://primevue.org/multiselect/#api).
 
 #### Textarea
 ```ts
@@ -315,6 +345,21 @@ import { Badge } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue Badge API](https://primevue.org/badge/#api).
+
+### Navigation
+
+#### Menu
+```ts
+import { Menu } from '@atlas/ui';
+```
+
+```vue
+<Menu :model="items" />
+```
+
+##### API
+
+Refer to the [PrimeVue Menu API](https://primevue.org/menu/#api).
 
 ### Feedback
 

--- a/ui/src/components/AutoComplete.vue
+++ b/ui/src/components/AutoComplete.vue
@@ -1,0 +1,117 @@
+<template>
+    <AutoComplete
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template #dropdownicon>
+            <ChevronDownIcon />
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </AutoComplete>
+</template>
+
+<script setup lang="ts">
+import ChevronDownIcon from '@primevue/icons/chevrondown';
+import AutoComplete, { type AutoCompletePassThroughOptions, type AutoCompleteProps } from 'primevue/autocomplete';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ AutoCompleteProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<AutoCompletePassThroughOptions>({
+    root: `inline-flex p-fluid:flex`,
+    pcInputText: {
+        root: `appearance-none rounded outline-hidden
+            bg-surface-0 dark:bg-surface-950
+            p-filled:bg-surface-50 dark:p-filled:bg-surface-800
+            text-surface-700 dark:text-surface-0
+            placeholder:text-surface-500 dark:placeholder:text-surface-400
+            border border-surface-300 dark:border-surface-700
+            enabled:hover:border-surface-400 dark:enabled:hover:border-surface-600
+            enabled:focus:border-primary
+            disabled:bg-surface-200 disabled:text-surface-500
+            dark:disabled:bg-surface-700 dark:disabled:text-surface-400
+            p-invalid:border-red-400 dark:p-invalid:border-red-300
+            p-invalid:placeholder:text-red-600 dark:p-invalid:placeholder:text-red-400
+            px-3 py-2 p-fluid:w-full
+            p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
+            p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]
+            p-has-dropdown:flex-auto p-has-dropdown:w-[1%] p-has-dropdown:rounded-e-none
+            transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`
+    },
+    inputMultiple: `m-0 list-none cursor-text overflow-hidden flex items-center flex-wrap
+        px-3 py-1 not-p-empty:px-1 gap-1 text-surface-700 dark:text-surface-0 bg-surface-0 dark:bg-surface-950
+        border border-surface-300 dark:border-surface-700 rounded p-has-dropdown:rounded-e-none w-full
+        hover:border-surface-400 dark:hover:border-surface-600 p-focus:border-primary
+        p-invalid:border-red-400 dark:p-invalid:border-red-300
+        p-filled:bg-surface-50 dark:p-filled:bg-surface-800
+        p-disabled:pointer-events-none p-disabled:bg-surface-200 p-disabled:text-surface-500 dark:p-disabled:bg-surface-700 dark:p-disabled:text-surface-400
+        shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]
+        transition-colors duration-200 outline-none`,
+    chipItem: ``,
+    pcChip: {
+        root: `inline-flex items-center rounded-sm gap-2 px-3 py-1
+            bg-surface-100 dark:bg-surface-800
+            text-surface-800 dark:text-surface-0
+            has-[img]:pt-1 has-[img]:pb-1
+            p-focus:bg-surface-200 p-focus:text-surface-800 dark:p-focus:bg-surface-700 dark:p-focus:text-surface-0
+            p-removable:pe-2`,
+        image: `rounded-full w-8 h-8 -ms-2`,
+        icon: `text-surface-800 dark:bg-surface-0 text-base w-4 h-4`,
+        label: ``,
+        removeIcon: `cursor-pointer text-base w-4 h-4 rounded-full
+            text-surface-800 dark:text-surface-0
+            focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary`
+    },
+    chipIcon: ``,
+    inputChip: `flex-auto inline-flex py-1 max-w-30`,
+    input: `border-none outline-none bg-transparent m-0 p-0 shadow-none rounded-none w-full text-inherit
+        placeholder:text-surface-500 dark:placeholder:text-surface-400`,
+    loader: `absolute top-1/2 -mt-2 end-3 p-has-dropdown:end-[3.25rem] animate-spin`,
+    dropdown: `cursor-pointer inline-flex items-center justify-center select-none overflow-hidden relative w-10 shrink-0 rounded-e
+        border border-s-0 border-surface-300 dark:border-surface-700
+        bg-surface-100 enabled:hover:bg-surface-200 enabled:active:bg-surface-300
+        text-surface-600 enabled:hover:text-surface-700 enabled:hover:active:text-surface-800
+        dark:bg-surface-800 dark:enabled:hover:bg-surface-700 dark:enabled:active:bg-surface-600
+        dark:text-surface-300 dark:enabled:hover:text-surface-200 dark:enabled:active:text-surface-100
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
+        transition-colors duration-200`,
+    dropdownIcon: ``,
+    overlay: `p-portal-self:min-w-full absolute top-0 left-0 rounded
+        bg-surface-0 dark:bg-surface-900
+        border border-surface-200 dark:border-surface-700
+        text-surface-700 dark:text-surface-0
+        shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_2px_4px_-2px_rgba(0,0,0,0.1)]`,
+    virtualScroller: ``,
+    listContainer: `overflow-auto`,
+    list: `m-0 p-1 list-none flex flex-col gap-[2px]`,
+    optionGroup: `m-0 px-3 py-2 text-surface-500 dark:text-surface-400 font-semibold bg-transparent`,
+    option: `cursor-pointer font-normal whitespace-nowrap relative overflow-hidden flex items-center
+    px-3 py-1.5 border-none text-surface-700 dark:text-surface-0 bg-transparent rounded-sm
+    p-focus:bg-surface-100 dark:p-focus:bg-surface-800 p-focus:text-surface-800 dark:p-focus:text-surface-0
+    p-selected:bg-primary-400 p-focus:p-selected:bg-primary-400 p-selected:text-white p-focus:p-selected:text-white dark:p-selected:bg-primary-600 dark:p-focus:p-selected:bg-primary-600
+    transition-colors duration-200 text-sm`,
+    emptyMessage: `px-3 py-2.5`,
+    searchResultMessage: ``,
+    selectedMessage: ``,
+    transition: {
+        enterFromClass: 'opacity-0 scale-y-75',
+        enterActiveClass: 'transition duration-120 ease-[cubic-bezier(0,0,0.2,1)]',
+        leaveActiveClass: 'transition-opacity duration-100 ease-linear',
+        leaveToClass: 'opacity-0'
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/Menu.vue
+++ b/ui/src/components/Menu.vue
@@ -1,0 +1,65 @@
+<template>
+    <Menu
+        ref="el"
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Menu>
+</template>
+
+<script setup lang="ts">
+import Menu, { type MenuPassThroughOptions, type MenuProps } from 'primevue/menu';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ MenuProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<MenuPassThroughOptions>({
+    root: `bg-surface-0 dark:bg-surface-900
+        text-surface-700 dark:text-surface-0
+        border border-surface-200 dark:border-surface-700
+        rounded-md min-w-52
+        p-popup:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_2px_4px_-2px_rgba(0,0,0,0.1)]`,
+    list: `m-0 p-1 list-none outline-none flex flex-col gap-[2px]`,
+    item: `p-disabled:opacity-60 p-disabled:pointer-events-none`,
+    itemContent: `group transition-colors duration-200 rounded-sm text-surface-700 dark:text-surface-0
+        p-focus:bg-surface-100 dark:p-focus:bg-surface-800 p-focus:text-surface-800 dark:p-focus:text-surface-0
+        hover:bg-surface-100 dark:hover:bg-surface-800 hover:text-surface-800 dark:hover:text-surface-0`,
+    itemLink: `cursor-pointer flex items-center no-underline overflow-hidden relative text-inherit
+        px-3 py-2 gap-2 select-none outline-none`,
+    itemIcon: `text-surface-400 dark:text-surface-500
+        p-focus:text-surface-500 dark:p-focus:text-surface-400
+        group-hover:text-surface-500 dark:group-hover:text-surface-400`,
+    itemLabel: ``,
+    submenuLabel: `bg-transparent px-3 py-2 text-surface-500 dark:text-surface-400 font-semibold`,
+    separator: `border-t border-surface-200 dark:border-surface-700`,
+    transition: {
+        enterFromClass: 'opacity-0 scale-y-75',
+        enterActiveClass: 'transition duration-120 ease-[cubic-bezier(0,0,0.2,1)]',
+        leaveActiveClass: 'transition-opacity duration-100 ease-linear',
+        leaveToClass: 'opacity-0'
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+
+const el = ref();
+
+defineExpose({
+    toggle: (event: Event) => el.value?.toggle(event),
+    show: (event: Event) => el.value?.show(event),
+    hide: () => el.value?.hide()
+});
+</script>

--- a/ui/src/components/MultiSelect.vue
+++ b/ui/src/components/MultiSelect.vue
@@ -1,0 +1,160 @@
+<template>
+    <MultiSelect
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template #dropdownicon>
+            <ChevronDownIcon />
+        </template>
+        <template #loadingicon>
+            <SpinnerIcon class="animate-spin" />
+        </template>
+        <template #filtericon>
+            <SearchIcon class="text-surface-400" />
+        </template>
+        <template #clearicon="{ clearCallback }">
+            <button
+                type="button"
+                @click.prevent.stop="clearCallback"
+                class="absolute top-1/2 -mt-2 end-10 cursor-pointer"
+                :class="props.disabled ? 'text-surface-300 dark:text-surface-700' : 'text-surface-400 dark:text-surface-300 hover:text-surface-500 '"
+            >
+                <TimesIcon class="w-4 h-4" />
+            </button>
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </MultiSelect>
+</template>
+
+<script setup lang="ts">
+import ChevronDownIcon from '@primevue/icons/chevrondown';
+import SearchIcon from '@primevue/icons/search';
+import SpinnerIcon from '@primevue/icons/spinner';
+import TimesIcon from '@primevue/icons/times';
+import MultiSelect, { type MultiSelectPassThroughOptions, type MultiSelectProps } from 'primevue/multiselect';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+const attrs = useAttrs();
+
+interface Props extends /* @vue-ignore */ MultiSelectProps {}
+const props = defineProps<Props>();
+
+const theme = ref<MultiSelectPassThroughOptions>({
+    root: `inline-flex cursor-pointer relative select-none rounded-md p-fluid:flex
+        bg-surface-0 dark:bg-surface-950
+        border border-surface-300 hover:border-surface-400 dark:border-surface-600 dark:hover:border-surface-500
+        p-focus:border-primary
+        p-filled:bg-surface-50 dark:p-filled:bg-surface-800
+        p-invalid:border-red-400 dark:p-invalid:border-red-500
+        p-disabled:bg-surface-200 p-disabled:text-surface-500 dark:p-disabled:bg-surface-700 dark:p-disabled:text-surface-400 p-disabled:pointer-events-none
+        transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`,
+    labelContainer: `overflow-hidden flex-auto`,
+    label: `flex items-center gap-1 h-full
+        whitespace-nowrap overflow-hidden text-ellipsis px-3 py-[9px]
+        text-surface-700 dark:text-surface-0 leading-[1.25rem]
+        p-placeholder:text-surface-500 dark:p-placeholder:text-surface-400
+        p-disabled:text-surface-500 dark:p-disabled:text-surface-400
+        p-empty:overflow-hidden p-empty:opacity-0
+        p-has-chip:px-1 p-has-chip:py-[4px] p-has-chip:gap-1
+        p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
+        p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem] p-disabled:opacity-50 p-disabled:pointer-events-none`,
+    chipItem: ``,
+    pcChip: {
+        root: `inline-flex items-center gap-2 px-3 py-[5px] rounded-sm
+            bg-primary-400 dark:bg-primary-600
+            text-white dark:text-surface-0
+            has-[img]:pt-1 has-[img]:pb-1
+            p-removable:pe-2`,
+        removeIcon: `cursor-pointer text-base w-4 h-4 rounded-full text-white dark:text-surface-0`
+    },
+    dropdown: `flex items-center justify-center shrink-0 bg-transparent
+        text-surface-400 w-10 rounded-e-md`,
+    overlay: `absolute top-0 left-0 rounded-md p-portal-self:min-w-full
+        bg-surface-0 dark:bg-surface-900
+        border border-surface-200 dark:border-surface-700
+        text-surface-700 dark:text-surface-0
+        shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_2px_4px_-2px_rgba(0,0,0,0.1)]`,
+    header: `flex items-center pt-2 pb-2 px-4 gap-2 border-b border-surface-200 dark:border-surface-700`,
+    pcHeaderCheckbox: {
+        root: `relative inline-flex select-none w-5 h-5 align-bottom`,
+        input: `peer cursor-pointer disabled:cursor-default appearance-none
+            absolute start-0 top-0 w-full h-full m-0 p-0 opacity-0 z-10
+            border border-transparent rounded-xs`,
+        box: `flex justify-center items-center rounded-sm w-5 h-5
+            border border-surface-300 dark:border-surface-700
+            bg-surface-0 dark:bg-surface-950
+            text-surface-700 dark:text-surface-0
+            peer-enabled:peer-hover:border-surface-400 dark:peer-enabled:peer-hover:border-surface-600
+            p-checked:border-primary-500 p-checked:bg-primary-500 p-checked:text-primary-contrast
+            peer-enabled:peer-hover:p-checked:bg-primary-emphasis peer-enabled:peer-hover:p-checked:border-primary-emphasis
+            peer-focus-visible:outline-1 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary peer-focus-visible:outline
+            p-disabled:bg-surface-200 dark:p-disabled:bg-surface-400 p-disabled:border-surface-300 dark:p-disabled:border-surface-700 p-disabled:text-surface-700 dark:p-disabled:text-surface-400
+            shadow-[0_1px_2px_0_rgba(18,18,23,0.05)] transition-colors duration-200`,
+        icon: `text-sm w-[0.875rem] h-[0.875rem] transition-none text-white`
+    },
+    pcFilterContainer: {
+        root: `relative flex-auto`
+    },
+    pcFilter: {
+        root: `w-full appearance-none rounded-md outline-hidden
+            bg-surface-0 dark:bg-surface-950
+            text-surface-700 dark:text-surface-0
+            placeholder:text-surface-500 dark:placeholder:text-surface-400
+            border border-surface-300 dark:border-surface-700
+            enabled:hover:border-surface-400 dark:enabled:hover:border-surface-600
+            enabled:focus:border-primary
+            disabled:bg-surface-200 disabled:text-surface-500
+            dark:disabled:bg-surface-700 dark:disabled:text-surface-400
+            ps-3 pe-10 py-2 p-fluid:w-full
+            transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`
+    },
+    pcFilterIconContainer: {
+        root: `absolute top-1/2 -mt-2 leading-none end-3 z-1`
+    },
+    listContainer: `overflow-auto`,
+    virtualScroller: ``,
+    list: `m-0 p-1 list-none gap-[2px] flex flex-col`,
+    optionGroup: `m-0 px-3 py-2 bg-transparent text-surface-500 dark:text-surface-400 font-semibold`,
+    option: `cursor-pointer font-normal whitespace-nowrap relative overflow-hidden flex items-center gap-2 px-3 py-1.5
+        rounded-sm text-surface-700 dark:text-surface-0 bg-transparent border-none
+        p-focus:bg-surface-100 dark:p-focus:bg-surface-800 p-focus:text-surface-800 dark:p-focus:text-surface-0
+        transition-colors duration-200 text-sm`,
+    optionLabel: ``,
+    pcOptionCheckbox: {
+        root: `relative inline-flex select-none w-5 h-5 align-bottom`,
+        input: `peer cursor-pointer disabled:cursor-default appearance-none
+            absolute start-0 top-0 w-full h-full m-0 p-0 opacity-0 z-10
+            border border-transparent rounded-xs`,
+        box: `flex justify-center items-center rounded-sm w-5 h-5
+            border border-surface-300 dark:border-surface-700
+            bg-surface-0 dark:bg-surface-950
+            text-surface-700 dark:text-surface-0
+            peer-enabled:peer-hover:border-surface-400 dark:peer-enabled:peer-hover:border-surface-600
+            p-checked:border-primary-500 p-checked:bg-primary-500 p-checked:text-primary-contrast
+            peer-enabled:peer-hover:p-checked:bg-primary-emphasis peer-enabled:peer-hover:p-checked:border-primary-emphasis
+            peer-focus-visible:outline-1 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary peer-focus-visible:outline
+            p-disabled:bg-surface-200 dark:p-disabled:bg-surface-400 p-disabled:border-surface-300 dark:p-disabled:border-surface-700 p-disabled:text-surface-700 dark:p-disabled:text-surface-400
+            shadow-[0_1px_2px_0_rgba(18,18,23,0.05)] transition-colors duration-200`,
+        icon: `text-sm w-[0.875rem] h-[0.875rem] transition-none text-white`
+    },
+    emptyMessage: `px-3 py-2.5`,
+    transition: {
+        enterFromClass: 'opacity-0 scale-y-75',
+        enterActiveClass: 'transition duration-120 ease-[cubic-bezier(0,0,0.2,1)]',
+        leaveActiveClass: 'transition-opacity duration-100 ease-linear',
+        leaveToClass: 'opacity-0'
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -20,3 +20,6 @@ export { default as Accordion } from './Accordion.vue';
 export { default as AccordionContent } from './AccordionContent.vue';
 export { default as AccordionHeader } from './AccordionHeader.vue';
 export { default as AccordionPanel } from './AccordionPanel.vue';
+export { default as AutoComplete } from './AutoComplete.vue';
+export { default as Menu } from './Menu.vue';
+export { default as MultiSelect } from './MultiSelect.vue';


### PR DESCRIPTION
## Summary
- wrap PrimeVue Menu with passthrough styling and expose toggle helpers
- add PrimeVue MultiSelect and AutoComplete wrappers with passthrough themes
- document new components in UI guide

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68a8e8b3298483259f38710b2fd87b48