### PR TITLE
feat(ui): add Errors component with theming passthrough

### DIFF
--- a/ui/src/components/Errors.vue
+++ b/ui/src/components/Errors.vue
@@ -1,0 +1,132 @@
+<template>
+    <div
+        v-bind="bindProps"
+        :class="[mergedPt.root.class, hasErrors || failed ? '' : 'hidden']"
+        @click="expandErrors = !expandErrors"
+    >
+        <div :class="mergedPt.header.class">
+            <div :class="mergedPt.icon.class">
+                <IconAlertCircle size="18" stroke-width="2.5" />
+            </div>
+            <div :class="mergedPt.titleContainer.class">
+                <div :class="mergedPt.title.class">
+                    <span>{{ title || (failed ? 'An error occurred' : 'Errors') }}</span>
+                    <span :class="[mergedPt.chevron.class, expandErrors ? 'rotate-180' : '']">
+                        <IconChevronDown size="16" />
+                    </span>
+                </div>
+            </div>
+        </div>
+        <transition name="expand" @enter="expandEnter" @leave="expandLeave">
+            <div v-show="expandErrors" :class="mergedPt.expandRoot.class">
+                <div :class="mergedPt.text.class">
+                    <ul v-if="hasErrors" role="list" :class="mergedPt.list.class">
+                        <li
+                            v-for="(error, index) in props.errors"
+                            :key="index"
+                            :class="mergedPt.listItem.class"
+                        >
+                            <slot :error="error">
+                                <span v-html="error" />
+                            </slot>
+                        </li>
+                    </ul>
+                    <div v-else-if="failed" :class="mergedPt.defaultError.class">
+                        <slot name="defaultError">
+                            <span>An unexpected error occurred. Please try again later.</span>
+                        </slot>
+                    </div>
+                </div>
+            </div>
+        </transition>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, useAttrs } from 'vue';
+import { IconAlertCircle, IconChevronDown } from '@tabler/icons-vue';
+import { isEmpty, ptMerge } from '../utils';
+
+interface ErrorsPassThroughOptions {
+    root?: any;
+    header?: any;
+    icon?: any;
+    titleContainer?: any;
+    title?: any;
+    chevron?: any;
+    expandRoot?: any;
+    text?: any;
+    list?: any;
+    listItem?: any;
+    defaultError?: any;
+}
+
+interface Props {
+    errors?: Record<string, any> | any[];
+    failed?: boolean;
+    title?: string;
+    expandDefault?: boolean;
+    pt?: ErrorsPassThroughOptions;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    errors: () => ({}),
+    failed: false,
+    title: '',
+    expandDefault: true,
+});
+const attrs = useAttrs();
+
+const expandErrors = ref(props.expandDefault);
+
+onMounted(() => {
+    expandErrors.value = props.expandDefault;
+});
+
+const theme = ref<ErrorsPassThroughOptions>({
+    root: 'rounded-md bg-red-50 dark:bg-red-900/20 border border-red-300 dark:border-red-800/70 p-4 cursor-pointer',
+    header: 'flex',
+    icon: 'relative top-1 shrink-0 text-red-700 self-start flex items-center',
+    titleContainer: 'ml-2 basis-full',
+    title: 'flex font-semibold text-red-700 dark:text-red-50 text-base',
+    chevron: 'ml-auto transition-transform duration-200',
+    expandRoot: 'overflow-hidden',
+    text: 'text-sm text-red-800 dark:text-red-50 pt-1',
+    list: 'list-disc pl-[26px] space-y-1 text-left',
+    listItem: '',
+    defaultError: 'pl-[26px] text-left',
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+
+const hasErrors = computed(() => !isEmpty(props.errors));
+
+function expandEnter(el: HTMLElement) {
+    el.style.height = '0';
+    el.offsetHeight; // force reflow
+    el.style.transition = 'height 200ms ease';
+    el.style.height = el.scrollHeight + 'px';
+}
+
+function expandLeave(el: HTMLElement) {
+    el.style.height = el.scrollHeight + 'px';
+    el.offsetHeight; // force reflow
+    el.style.transition = 'height 200ms ease';
+    el.style.height = '0';
+}
+
+const passThroughProps = computed(() => {
+    const { pt, errors, failed, title, expandDefault, ...rest } = props as any;
+    return rest;
+});
+
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>
+
+<style scoped>
+.expand-enter-active,
+.expand-leave-active {
+    transition: height 200ms ease;
+}
+</style>
+

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -8,6 +8,7 @@ export { default as InputNumber } from './InputNumber.vue';
 export { default as InputOtp } from './InputOtp.vue';
 export { default as InputText } from './InputText.vue';
 export { default as Alert } from './Alert.vue';
+export { default as Errors } from './Errors.vue';
 export { default as Select } from './Select.vue';
 export { default as Textarea } from './Textarea.vue';
 export { default as Avatar } from './Avatar.vue';

--- a/ui/tests/components/Errors.test.ts
+++ b/ui/tests/components/Errors.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { Errors } from '../../src/components';
+
+describe('Errors', () => {
+    it('renders provided errors', () => {
+        const wrapper = mount(Errors, { props: { errors: ['foo'] } });
+        const items = wrapper.findAll('li');
+        expect(items.length).toBe(1);
+        expect(items[0].text()).toBe('foo');
+    });
+
+    it('applies pass-through classes', () => {
+        const wrapper = mount(Errors, {
+            props: { errors: ['foo'], pt: { root: 'test-root' } },
+        });
+        expect(wrapper.attributes('class')).toContain('test-root');
+    });
+});
+


### PR DESCRIPTION
## Summary
- add `Errors` Vue component for displaying error lists
- allow pass-through theming via `pt` prop and attribute binding
- include tests and export in component index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8eaa7ce908325a6e94329973b9fb6