### PR TITLE
feat(ui): add toast and toggle components

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -35,6 +35,8 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [MultiSelect](#multiselect)
   - [Textarea](#textarea)
   - [Checkbox](#checkbox)
+  - [ToggleButton](#togglebutton)
+  - [ToggleSwitch](#toggleswitch)
 - [Layout](#layout)
   - [ScrollFrame](#scrollframe)
   - [Accordion](#accordion)
@@ -49,6 +51,7 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Menu](#menu)
 - [Feedback](#feedback)
   - [Alert](#alert)
+  - [Toast](#toast)
 
 ### Actions
 
@@ -216,6 +219,33 @@ import { Checkbox } from '@atlas/ui';
 
 See the [PrimeVue Checkbox API](https://primevue.org/checkbox/#api).
 
+#### ToggleButton
+```ts
+import { ToggleButton } from '@atlas/ui';
+```
+
+```vue
+<ToggleButton v-model="checked" />
+```
+
+##### API
+
+Refer to the [PrimeVue ToggleButton API](https://primevue.org/togglebutton/#api).
+
+#### ToggleSwitch
+```ts
+import { ToggleSwitch } from '@atlas/ui';
+```
+
+```vue
+<ToggleSwitch v-model="checked" />
+```
+
+##### API
+
+Refer to the [PrimeVue ToggleSwitch API](https://primevue.org/toggleswitch/#api).
+
+
 ### Layout
 
 #### ScrollFrame
@@ -376,3 +406,16 @@ import { Alert } from '@atlas/ui';
 
 - `warning` – use warning styling.
 - `hideIcon` – hide the default icon.
+
+#### Toast
+```ts
+import { Toast } from '@atlas/ui';
+```
+
+```vue
+<Toast />
+```
+
+##### API
+
+Refer to the [PrimeVue Toast API](https://primevue.org/toast/#api).

--- a/ui/src/components/Toast.vue
+++ b/ui/src/components/Toast.vue
@@ -1,0 +1,74 @@
+<template>
+    <Toast
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template #icon>
+            <IconCircleCheckFilled class="size-6 text-green-500 dark:text-green-400" />
+        </template>
+        <template #closeicon>
+            <TimesIcon />
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Toast>
+</template>
+
+<script setup lang="ts">
+import TimesIcon from '@primevue/icons/times';
+import { IconCircleCheckFilled } from '@tabler/icons-vue';
+import Toast, { type ToastPassThroughOptions, type ToastProps } from 'primevue/toast';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ ToastProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<ToastPassThroughOptions>({
+    root: `left-[5px] whitespace-pre-line break-words
+        p-top-center:-translate-x-1/2 p-bottom-center:-translate-x-1/2
+        p-center:min-w-[20vw] p-center:-translate-x-1/2 p-center:-translate-y-1/2`,
+    message: `backdrop-blur-[10px] mb-2 shadow-md not-p-custom:border not-p-custom:backdrop-blur-sm dark:not-p-custom:backdrop-blur-md not-p-custom:rounded-full
+        p-info:bg-blue-50/95 p-info:border-blue-200 p-info:text-blue-600 dark:p-info:bg-blue-500/15 dark:p-info:border-blue-700/35 dark:p-info:text-blue-500
+        p-success:bg-green-50/95 p-success:border-green-200 p-success:text-green-600 dark:p-success:bg-green-500/15 dark:p-success:border-green-700/35 dark:p-success:text-green-500
+        p-warn:bg-yellow-50/95 p-warn:border-yellow-200 p-warn:text-yellow-600 dark:p-warn:bg-yellow-500/15 dark:p-warn:border-yellow-700/35 dark:p-warn:text-yellow-500
+        p-error:bg-red-50/95 p-error:border-red-200 p-error:text-red-600 dark:p-error:bg-red-500/15 dark:p-error:border-red-700/35 dark:p-error:text-red-500
+        p-secondary:bg-surface-100 p-secondary:border-surface-200 p-secondary:text-surface-600 dark:p-secondary:bg-surface-800 dark:p-secondary:border-surface-700 dark:p-secondary:text-surface-300
+        p-contrast:bg-surface-900 p-contrast:border-surface-950 p-contrast:text-surface-50 dark:p-contrast:bg-surface-0 dark:p-contrast:border-surface-100 dark:p-contrast:text-surface-950 !text-white !bg-surface-800 border !border-surface-700`,
+    messageContent: `flex items-center py-3 px-4 gap-2`,
+    messageIcon: `flex-shrink-0 text-lg w-[1.125rem] h-[1.125rem]`,
+    messageText: `flex-auto flex flex-col gap-4`,
+    summary: `font-medium text-base`,
+    detail: `font-medium text-sm text-surface-700 dark:text-surface-0
+        p-contrast:text-surface-0 dark:p-contrast:text-surface-950`,
+    buttonContainer: ``,
+    closeButton: `opacity-50 flex items-center justify-center overflow-hidden relative cursor-pointer bg-transparent select-none
+        transition-colors duration-200 text-inherit w-6 h-6 rounded-full top-[50%] -end-1/4 p-0 border-none
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2
+        p-info:hover:bg-blue-100 p-info:focus-visible:outline-blue-600 dark:p-info:hover:bg-white/5 dark:p-info:focus-visible:outline-blue-500
+        p-success:hover:bg-green-100 p-success:focus-visible:outline-green-600 dark:p-success:hover:bg-white/5 dark:p-success:focus-visible:outline-green-500
+        p-warn:hover:bg-yellow-100 p-warn:focus-visible:outline-yellow-600 dark:p-warn:hover:bg-white/5 dark:p-warn:focus-visible:outline-yellow-500
+        p-error:hover:bg-red-100 p-error:focus-visible:outline-red-600 dark:p-error:hover:bg-white/5 dark:p-error:focus-visible:outline-red-500
+        p-secondary:hover:bg-surface-200 p-secondary:focus-visible:outline-surface-600 dark:p-secondary:hover:bg-surface-700 dark:p-secondary:focus-visible:outline-surface-300
+        p-contrast:hover:bg-surface-800 p-contrast:focus-visible:outline-surface-50 dark:p-contrast:hover:bg-surface-100 dark:p-contrast:focus-visible:outline-surface-950 hidden`,
+    closeIcon: `text-base w-4 h-4`,
+    transition: {
+        enterFromClass: 'opacity-0 translate-y-1/2',
+        enterActiveClass: 'transition-all duration-500',
+        leaveFromClass: 'max-h-[1000px]',
+        leaveActiveClass: 'transition-all duration-500',
+        leaveToClass: 'max-h-0 opacity-0 mb-0 overflow-hidden'
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/ToggleButton.vue
+++ b/ui/src/components/ToggleButton.vue
@@ -1,0 +1,51 @@
+<template>
+    <ToggleButton
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </ToggleButton>
+</template>
+
+<script setup lang="ts">
+import ToggleButton, { type ToggleButtonPassThroughOptions, type ToggleButtonProps } from 'primevue/togglebutton';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ ToggleButtonProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<ToggleButtonPassThroughOptions>({
+    root: `inline-flex items-center justify-center overflow-hidden relative cursor-pointer select-none
+        border border-surface-100 dark:border-surface-950 rounded-md
+        bg-surface-100 dark:bg-surface-950
+        text-surface-500 dark:text-surface-400
+        p-checked:text-surface-700 dark:p-checked:text-surface-0
+        text-base font-medium
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
+        disabled:cursor-default
+        disabled:bg-surface-200 disabled:border-surface-200 disabled:text-surface-500
+        disabled:dark:bg-surface-700 disabled:dark:border-surface-700 disabled:dark:text-surface-400
+        p-invalid:border-red-400 dark:p-invalid:border-red-300
+        transition-colors duration-200
+        p-1 p-small:text-sm p-large:text-lg
+    `,
+    content: `relative flex-auto inline-flex items-center justify-center gap-2 py-1 px-3
+        rounded-md transition-colors duration-200
+        p-checked:bg-surface-0 dark:p-checked:bg-surface-800 p-checked:shadow-[0px_1px_2px_0px_rgba(0,0,0,0.02),0px_1px_2px_0px_rgba(0,0,0,0.04)]`,
+    icon: ``,
+    label: ``
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/ToggleSwitch.vue
+++ b/ui/src/components/ToggleSwitch.vue
@@ -1,0 +1,50 @@
+<template>
+    <ToggleSwitch
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </ToggleSwitch>
+</template>
+
+<script setup lang="ts">
+import ToggleSwitch, { type ToggleSwitchPassThroughOptions, type ToggleSwitchProps } from 'primevue/toggleswitch';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ ToggleSwitchProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<ToggleSwitchPassThroughOptions>({
+    root: `inline-block w-10 h-6`,
+    input: `peer cursor-pointer disabled:cursor-default appearance-none absolute top-0 start-0 w-full h-full m-0 p-0 opacity-0 z-10 rounded-[30px]`,
+    slider: `inline-block w-full h-full rounded-[30px] shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]
+        bg-surface-300 dark:bg-surface-700
+        border border-transparent
+        transition-colors duration-200
+        peer-enabled:peer-hover:bg-surface-400 dark:peer-enabled:peer-hover:bg-surface-600
+        p-checked:bg-primary peer-enabled:peer-hover:p-checked:bg-primary-emphasis
+        p-invalid:border-red-400 dark:p-invalid:border-red-300
+        p-disabled:bg-surface-200 dark:p-disabled:bg-surface-600
+        peer-focus-visible:outline peer-focus-visible:outline-1 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary`,
+    handle: `absolute top-1/2 flex justify-center items-center
+        bg-surface-0 dark:bg-surface-400
+        text-surface-500 dark:text-surface-900
+        w-4 h-4 start-1 -mt-2 rounded-full
+        transition-[background,color,left] duration-200
+        p-checked:bg-surface-0 dark:p-checked:bg-surface-900 p-checked:text-primary p-checked:start-5
+        p-disabled:bg-surface-700 dark:p-disabled:bg-surface-900`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -31,3 +31,6 @@ export { default as LabelRadioButton } from './LabelRadioButton.vue';
 export { default as Popover } from './Popover.vue';
 export { default as RadioButton } from './RadioButton.vue';
 export { default as TooltipIcon } from './TooltipIcon.vue';
+export { default as Toast } from './Toast.vue';
+export { default as ToggleButton } from './ToggleButton.vue';
+export { default as ToggleSwitch } from './ToggleSwitch.vue';


### PR DESCRIPTION
## Summary
- add Toast component with default icon and close slots
- add ToggleButton and ToggleSwitch components with passthrough themes
- document new components and export them

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8f1402a5483259011d13a65bb4a31