### PR TITLE
feat: add tabs components

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -43,6 +43,7 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Accordion](#accordion)
   - [Card](#card)
   - [Divider](#divider)
+  - [Tabs](#tabs)
 - [Data Display](#data-display)
   - [Avatar](#avatar)
   - [AvatarGroup](#avatargroup)
@@ -351,6 +352,28 @@ import { Divider } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue Divider API](https://primevue.org/divider/#api).
+
+#### Tabs
+```ts
+import { Tabs, Tab, TabList, TabPanel, TabPanels } from '@atlas/ui';
+```
+
+```vue
+<Tabs value="0">
+  <TabList>
+    <Tab value="0">One</Tab>
+    <Tab value="1">Two</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel value="0">Content 1</TabPanel>
+    <TabPanel value="1">Content 2</TabPanel>
+  </TabPanels>
+</Tabs>
+```
+
+##### API
+
+Refer to the [PrimeVue Tabs API](https://primevue.org/tabs/#api).
 
 ### Data Display
 

--- a/ui/src/components/Tab.vue
+++ b/ui/src/components/Tab.vue
@@ -1,0 +1,39 @@
+<template>
+    <Tab
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <slot></slot>
+    </Tab>
+</template>
+
+<script setup lang="ts">
+import Tab, { type TabPassThroughOptions, type TabProps } from 'primevue/tab';
+import { ref, useAttrs, computed } from 'vue';
+import { ptMerge, ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ TabProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<TabPassThroughOptions>({
+    root: `flex-shrink-0 cursor-pointer select-none relative whitespace-nowrap py-4 px-6
+        border-b-2 border-surface-200 dark:border-surface-700 font-semibold
+        text-surface-500 dark:text-surface-400
+        transition-colors duration-200 -mb-[2px]
+        not-p-active:enabled:hover:text-surface-700 dark:not-p-active:enabled:hover:text-surface-0
+        p-active:border-primary p-active:text-primary
+        hover:bg-surface-100 dark:hover:bg-surface-800
+        disabled:pointer-events-none disabled:opacity-60
+        focus-visible:z-10 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-1px] focus-visible:outline-primary`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/TabList.vue
+++ b/ui/src/components/TabList.vue
@@ -1,0 +1,45 @@
+<template>
+    <TabList
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <slot></slot>
+    </TabList>
+</template>
+
+<script setup lang="ts">
+import TabList, { type TabListPassThroughOptions, type TabListProps } from 'primevue/tablist';
+import { ref, useAttrs, computed } from 'vue';
+import { ptMerge, ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ TabListProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const navButton = `!absolute flex-shrink-0 top-0 z-20 h-full flex items-center justify-center cursor-pointer
+        text-surface-500 dark:text-surface-400 hover:text-surface-700 dark:hover:text-surface-0 w-10
+        shadow-[0px_0px_10px_50px_rgba(255,255,255,0.6)] dark:shadow-[0px_0px_10px_50px] dark:shadow-surface-900/50
+        focus-visible:z-10 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-1px] focus-visible:outline-primary
+        transition-colors duration-200`;
+
+const theme = ref<TabListPassThroughOptions>({
+    root: `flex relative`,
+    prevButton: navButton + ` start-0`,
+    nextButton: navButton + ` end-0`,
+    content: `flex-grow
+        p-scrollable:overflow-x-auto p-scrollable:overflow-y-hidden p-scrollable:overscroll-y-contain p-scrollable:overscroll-x-auto
+        scroll-smooth [scrollbar-width:none]`,
+    tabList: `relative flex bg-surface-0 dark:bg-surface-900 border-b-2 border-surface-200 dark:border-surface-700
+        p-scrollable:overflow-hidden`,
+    activeBar: `z-10 block absolute -bottom-px h-px bg-primary transition-[left] duration-200 ease-[cubic-bezier(0.35,0,0.25,1)]`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/TabPanel.vue
+++ b/ui/src/components/TabPanel.vue
@@ -1,0 +1,31 @@
+<template>
+    <TabPanel
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <slot></slot>
+    </TabPanel>
+</template>
+
+<script setup lang="ts">
+import TabPanel, { type TabPanelPassThroughOptions, type TabPanelProps } from 'primevue/tabpanel';
+import { ref, useAttrs, computed } from 'vue';
+import { ptMerge, ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ TabPanelProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<TabPanelPassThroughOptions>({
+    root: ``
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/TabPanels.vue
+++ b/ui/src/components/TabPanels.vue
@@ -1,0 +1,32 @@
+<template>
+    <TabPanels
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <slot></slot>
+    </TabPanels>
+</template>
+
+<script setup lang="ts">
+import TabPanels, { type TabPanelsPassThroughOptions, type TabPanelsProps } from 'primevue/tabpanels';
+import { ref, useAttrs, computed } from 'vue';
+import { ptMerge, ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ TabPanelsProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<TabPanelsPassThroughOptions>({
+    root: `text-surface-700 dark:text-surface-0
+        pt-[0.875rem] pb-[1.125rem] px-6 outline-none text-base`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/Tabs.vue
+++ b/ui/src/components/Tabs.vue
@@ -1,0 +1,33 @@
+<template>
+    <Tabs
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Tabs>
+</template>
+
+<script setup lang="ts">
+import Tabs, { type TabsPassThroughOptions, type TabsProps } from 'primevue/tabs';
+import { ref, useAttrs, computed } from 'vue';
+import { ptMerge, ptViewMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ TabsProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<TabsPassThroughOptions>({
+    root: `flex flex-col`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -33,3 +33,8 @@ export { default as TooltipIcon } from './TooltipIcon.vue';
 export { default as Toast } from './Toast.vue';
 export { default as ToggleButton } from './ToggleButton.vue';
 export { default as ToggleSwitch } from './ToggleSwitch.vue';
+export { default as Tabs } from './Tabs.vue';
+export { default as Tab } from './Tab.vue';
+export { default as TabList } from './TabList.vue';
+export { default as TabPanel } from './TabPanel.vue';
+export { default as TabPanels } from './TabPanels.vue';


### PR DESCRIPTION
## Summary
- add PrimeVue-based Tabs wrapper components (Tabs, Tab, TabList, TabPanel, TabPanels)
- document Tabs usage and passthrough support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8ffbc63c08325baf7ed8a42064492