### PR TITLE
feat(ui): add slider, password, paginator, and pagination components

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -38,6 +38,8 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [LabelChoice](#labelchoice)
   - [ToggleButton](#togglebutton)
   - [ToggleSwitch](#toggleswitch)
+  - [Password](#password)
+  - [Slider](#slider)
 - [Layout](#layout)
   - [ScrollFrame](#scrollframe)
   - [Accordion](#accordion)
@@ -51,6 +53,8 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   - [Badge](#badge)
 - [Navigation](#navigation)
   - [Menu](#menu)
+  - [Paginator](#paginator)
+  - [Pagination](#pagination)
 - [Feedback](#feedback)
   - [Alert](#alert)
   - [Toast](#toast)
@@ -278,6 +282,32 @@ import { ToggleSwitch } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue ToggleSwitch API](https://primevue.org/toggleswitch/#api).
+#### Password
+```ts
+import { Password } from '@atlas/ui';
+```
+
+```vue
+<Password v-model="value" />
+```
+
+##### API
+
+See the [PrimeVue Password API](https://primevue.org/password/#api).
+
+#### Slider
+```ts
+import { Slider } from '@atlas/ui';
+```
+
+```vue
+<Slider v-model="value" />
+```
+
+##### API
+
+See the [PrimeVue Slider API](https://primevue.org/slider/#api).
+
 
 
 ### Layout
@@ -446,6 +476,33 @@ import { Menu } from '@atlas/ui';
 ##### API
 
 Refer to the [PrimeVue Menu API](https://primevue.org/menu/#api).
+#### Paginator
+```ts
+import { Paginator } from '@atlas/ui';
+```
+
+```vue
+<Paginator :totalRecords="100" :rows="10" />
+```
+
+##### API
+
+See the [PrimeVue Paginator API](https://primevue.org/paginator/#api).
+
+#### Pagination
+```ts
+import { Pagination } from '@atlas/ui';
+```
+
+```vue
+<Pagination :links="links" />
+```
+
+##### Props
+
+- `links` – array of pagination link objects.
+- `linkComponent` – component used for each link. Defaults to 'a'.
+
 
 ### Feedback
 

--- a/ui/src/components/Pagination.vue
+++ b/ui/src/components/Pagination.vue
@@ -1,0 +1,58 @@
+<template>
+    <div
+        v-bind="bindProps"
+        :class="mergedPt.root.class"
+    >
+        <component
+            v-for="link in links"
+            :key="link.label"
+            :is="linkComponent"
+            :href="link.url ?? ''"
+            v-html="link.label"
+            preserve-scroll
+            :class="[mergedPt.link.class, {
+                'bg-gray-200 dark:bg-gray-600 dark:text-white text-gray-900 font-semibold': link.active,
+                '!text-gray-300': !link.url
+            }]"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, useAttrs, ref } from 'vue';
+import { ptMerge } from '../utils';
+
+interface PaginationLink {
+    label: string;
+    url?: string | null;
+    active?: boolean;
+}
+
+interface PaginationPassThroughOptions {
+    root?: any;
+    link?: any;
+}
+
+interface Props {
+    links: PaginationLink[];
+    linkComponent?: string | object;
+    pt?: PaginationPassThroughOptions;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    linkComponent: 'a',
+});
+const attrs = useAttrs();
+
+const theme = ref<PaginationPassThroughOptions>({
+    root: 'flex items-center justify-center flex-wrap gap-1',
+    link: 'flex items-center justify-center px-3 py-2 text-sm rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700',
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, links, linkComponent, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/Paginator.vue
+++ b/ui/src/components/Paginator.vue
@@ -1,0 +1,68 @@
+<template>
+    <Paginator
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template #container="{ page, pageCount, pageLinks, changePageCallback, firstPageCallback, lastPageCallback, prevPageCallback, nextPageCallback }">
+            <div class="flex flex-wrap gap-2 items-center justify-center">
+                <Button text rounded @click="firstPageCallback" :disabled="page === 0">
+                    <template #icon>
+                        <AngleDoubleLeftIcon />
+                    </template>
+                </Button>
+                <Button text rounded @click="prevPageCallback" :disabled="page === 0">
+                    <template #icon>
+                        <AngleLeftIcon />
+                    </template>
+                </Button>
+                <div class="items-center justify-center gap-2 hidden sm:flex">
+                    <Button v-for="pageLink of pageLinks" :key="pageLink" :text="page + 1 !== pageLink" rounded @click="() => changePageCallback(pageLink - 1)" :class="['shrink-0 min-w-10 h-10', { 'bg-highlight!': page + 1 === pageLink }]">
+                        {{ pageLink }}
+                    </Button>
+                </div>
+                <Button text rounded @click="nextPageCallback" :disabled="page === pageCount! - 1">
+                    <template #icon>
+                        <AngleRightIcon />
+                    </template>
+                </Button>
+                <Button text rounded @click="lastPageCallback" :disabled="page === pageCount! - 1">
+                    <template #icon>
+                        <AngleDoubleRightIcon />
+                    </template>
+                </Button>
+            </div>
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Paginator>
+</template>
+
+<script setup lang="ts">
+import AngleDoubleLeftIcon from '@primevue/icons/angledoubleleft';
+import AngleDoubleRightIcon from '@primevue/icons/angledoubleright';
+import AngleLeftIcon from '@primevue/icons/angleleft';
+import AngleRightIcon from '@primevue/icons/angleright';
+import Paginator, { type PaginatorPassThroughOptions, type PaginatorProps } from 'primevue/paginator';
+import Button from './Button.vue';
+import { ref, computed, useAttrs } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ PaginatorProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<PaginatorPassThroughOptions>({
+    root: `flex items-center justify-center flex-wrap py-2 px-4 rounded-md gap-1
+        bg-surface-0 dark:bg-surface-900 text-surface-700 dark:text-surface-0`
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/Password.vue
+++ b/ui/src/components/Password.vue
@@ -1,0 +1,77 @@
+<template>
+    <Password
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template #maskicon="{ toggleCallback }">
+            <EyeSlashIcon @click="toggleCallback" class="end-3 text-surface-500 dark:text-surface-400 absolute top-1/2 -mt-2 w-4 h-4" />
+        </template>
+        <template #unmaskicon="{ toggleCallback }">
+            <EyeIcon @click="toggleCallback" class="end-3 text-surface-500 dark:text-surface-400 absolute top-1/2 -mt-2 w-4 h-4" />
+        </template>
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Password>
+</template>
+
+<script setup lang="ts">
+import EyeIcon from '@primevue/icons/eye';
+import EyeSlashIcon from '@primevue/icons/eyeslash';
+import Password, { type PasswordPassThroughOptions, type PasswordProps } from 'primevue/password';
+import { ref, computed, useAttrs } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ PasswordProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<PasswordPassThroughOptions>({
+    root: `inline-flex relative p-fluid:flex`,
+    pcInputText: {
+        root: `appearance-none rounded-md outline-hidden
+        bg-surface-0 dark:bg-surface-950
+        p-filled:bg-surface-50 dark:p-filled:bg-surface-800
+        text-surface-700 dark:text-surface-0
+        placeholder:text-surface-500 dark:placeholder:text-surface-400
+        border border-surface-300 dark:border-surface-700
+        enabled:hover:border-surface-400 dark:enabled:hover:border-surface-600
+        enabled:focus:border-primary
+        disabled:bg-surface-200 disabled:text-surface-500
+        dark:disabled:bg-surface-700 dark:disabled:text-surface-400
+        p-invalid:border-red-400 dark:p-invalid:border-red-300
+        p-invalid:placeholder:text-red-600 dark:p-invalid:placeholder:text-red-400
+        px-3 py-2 p-fluid:w-full p-has-e-icon:pe-10
+        p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
+        p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]
+        transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`
+    },
+    overlay: `p-3 rounded-md p-portal-self:min-w-full
+        bg-surface-0 dark:bg-surface-900
+        border border-surface-200 dark:border-surface-700
+        text-surface-700 dark:text-surface-0
+        shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_2px_4px_-2px_rgba(0,0,0,0.1)]`,
+    content: `flex flex-col gap-2`,
+    meter: `h-3 bg-surface-200 dark:bg-surface-700 rounded-md`,
+    meterLabel: `h-full w-0 transition-[width] duration-1000 ease-in-out rounded-md
+        p-weak:bg-red-500 dark:p-weak:bg-red-400
+        p-medium:bg-amber-500 dark:p-medium:bg-amber-400
+        p-strong:bg-green-500 dark:p-strong:bg-green-400`,
+    meterText: ``,
+    transition: {
+        enterFromClass: 'opacity-0 scale-y-75',
+        enterActiveClass: 'transition duration-120 ease-[cubic-bezier(0,0,0.2,1)]',
+        leaveActiveClass: 'transition-opacity duration-100 ease-linear',
+        leaveToClass: 'opacity-0'
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/Slider.vue
+++ b/ui/src/components/Slider.vue
@@ -1,0 +1,52 @@
+<template>
+    <Slider
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </Slider>
+</template>
+
+<script setup lang="ts">
+import Slider, { type SliderPassThroughOptions, type SliderProps } from 'primevue/slider';
+import { ref, computed, useAttrs } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ SliderProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const handleCommon = `cursor-grab touch-none flex items-center justify-center h-[20px] w-[20px]
+        bg-surface-200 dark:bg-surface-700 rounded-full
+        transition-colors duration-200
+        focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
+        before:w-[16px] before:h-[16px] before:block before:rounded-full
+        before:bg-surface-0 dark:before:bg-surface-950
+        before:shadow-[0px_0.5px_0px_0px_rgba(0,0,0,0.08),0px_1px_1px_0px_rgba(0,0,0,0.14)]
+        before:transition-colors before:duration-200
+        p-horizontal:top-1/2 p-horizontal:-mt-[10px] p-horizontal:-ms-[10px]
+        p-vertical:start-1/2 p-vertical:-mb-[10px] p-vertical:-ms-[10px]`;
+
+const theme = ref<SliderPassThroughOptions>({
+    root: `relative bg-surface-200 dark:bg-surface-700 rounded-xs
+            p-horizontal:h-[3px]
+            p-vertical:min-h-[100px] p-vertical:w-[3px]`,
+    range: `block bg-primary rounded-xs
+            p-horizontal:top-0 p-horizontal:start-0 p-horizontal:h-full
+            p-vertical:bottom-0 p-vertical:start-0 p-vertical:w-full`,
+    handle: handleCommon,
+    startHandler: handleCommon,
+    endHandler: handleCommon
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -38,3 +38,7 @@ export { default as Tab } from './Tab.vue';
 export { default as TabList } from './TabList.vue';
 export { default as TabPanel } from './TabPanel.vue';
 export { default as TabPanels } from './TabPanels.vue';
+export { default as Slider } from './Slider.vue';
+export { default as Password } from './Password.vue';
+export { default as Paginator } from './Paginator.vue';
+export { default as Pagination } from './Pagination.vue';


### PR DESCRIPTION
## Summary
- add Slider component with passthrough theme support
- add Password component with custom icons and pt merging
- add Paginator component built on PrimeVue with themed controls
- add Pagination link component for server pagination
- document new components in ui guide

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9015635b08325a7277a166af550d1