### PR TITLE
fix(ui): correct confirm button pass-through in DialogConfirmation

### DIFF
--- a/ui/src/components/DialogConfirmation.vue
+++ b/ui/src/components/DialogConfirmation.vue
@@ -80,7 +80,9 @@ const theme = computed<DialogConfirmationPassThroughOptions>(() => ({
     message: 'text-gray-700 dark:text-gray-200',
     actions: 'flex justify-center items-center space-x-4 py-2',
     confirmButton: {
-        root: 'text-white bg-red-600 enabled:hover:bg-red-700 border-red-600 enabled:active:border-red-400 enabled:active:bg-red-600 enabled:hover:border-red-emphasis',
+        root: {
+            class: 'text-white bg-red-600 enabled:hover:bg-red-700 border-red-600 enabled:active:border-red-400 enabled:active:bg-red-600 enabled:hover:border-red-emphasis',
+        },
     },
     cancelButton: {},
 }));


### PR DESCRIPTION
## Summary
- ensure DialogConfirmation's confirm button uses proper pass-through object so styling applies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aa23eea2e08325ac03e07f884801f8