### PR TITLE
style: ensure template-first order in playground components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ All contributions must follow the architecture and coding conventions outlined i
 ## Conventions
 - Adhere to the architecture and coding standards in [docs/backend-guide.md](docs/backend-guide.md).
 - Front-end architecture and patterns are covered in [docs/frontend-guide.md](docs/frontend-guide.md).
+- In Vue single-file components, always order blocks as `<template>`, then `<script>`, and finally `<style>`.
 - UI docs:
   - [Composables](docs/ui/composables.md)
   - [Utils](docs/ui/utils.md)

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,7 +1,7 @@
-<script setup>
-import { RouterView } from 'vue-router';
-</script>
-
 <template>
   <RouterView />
 </template>
+
+<script setup>
+import { RouterView } from 'vue-router';
+</script>

--- a/playground/src/components/LinkPaginator.vue
+++ b/playground/src/components/LinkPaginator.vue
@@ -1,3 +1,9 @@
+<template>
+  <div class="flex items-center justify-center py-2">
+    <span class="text-sm text-slate-500">Pagination placeholder</span>
+  </div>
+</template>
+
 <script setup>
 const props = defineProps({
   links: {
@@ -10,9 +16,3 @@ const props = defineProps({
   },
 });
 </script>
-
-<template>
-  <div class="flex items-center justify-center py-2">
-    <span class="text-sm text-slate-500">Pagination placeholder</span>
-  </div>
-</template>

--- a/playground/src/components/RouterLink.vue
+++ b/playground/src/components/RouterLink.vue
@@ -1,3 +1,7 @@
+<template>
+  <RouterLink :to="props.href" v-bind="attrs"><slot /></RouterLink>
+</template>
+
 <script setup>
 import { RouterLink } from 'vue-router';
 import { useAttrs } from 'vue';
@@ -11,7 +15,3 @@ const props = defineProps({
 
 const attrs = useAttrs();
 </script>
-
-<template>
-  <RouterLink :to="props.href" v-bind="attrs"><slot /></RouterLink>
-</template>

--- a/playground/src/components/UserModals.vue
+++ b/playground/src/components/UserModals.vue
@@ -1,3 +1,27 @@
+<template>
+  <DrawerForm
+    v-model="addEditUserVisible"
+    :title="form.id ? 'Edit user' : 'Add user'"
+    :loading="form.processing"
+    :errors="form.errors"
+    @submit="submit"
+  >
+    <div class="space-y-4 w-full">
+      <LabelField name="name" label="Name">
+        <InputText id="name" v-model="form.name" type="text" />
+      </LabelField>
+      <LabelField name="email" label="Email">
+        <InputText id="email" v-model="form.email" type="text" />
+      </LabelField>
+    </div>
+  </DrawerForm>
+  <DialogConfirmation
+    v-model="deleteUserVisible"
+    :message="`Are you sure you want to delete this user?`"
+    @confirm="confirmDelete"
+  />
+</template>
+
 <script setup>
 import { reactive, watch } from 'vue';
 import { DrawerForm, DialogConfirmation, LabelField, InputText, useModal } from '@atlas/ui';
@@ -34,27 +58,3 @@ const confirmDelete = () => {
   close('DELETE_USER');
 };
 </script>
-
-<template>
-  <DrawerForm
-    v-model="addEditUserVisible"
-    :title="form.id ? 'Edit user' : 'Add user'"
-    :loading="form.processing"
-    :errors="form.errors"
-    @submit="submit"
-  >
-    <div class="space-y-4 w-full">
-      <LabelField name="name" label="Name">
-        <InputText id="name" v-model="form.name" type="text" />
-      </LabelField>
-      <LabelField name="email" label="Email">
-        <InputText id="email" v-model="form.email" type="text" />
-      </LabelField>
-    </div>
-  </DrawerForm>
-  <DialogConfirmation
-    v-model="deleteUserVisible"
-    :message="`Are you sure you want to delete this user?`"
-    @confirm="confirmDelete"
-  />
-</template>

--- a/playground/src/layouts/ComponentsLayout.vue
+++ b/playground/src/layouts/ComponentsLayout.vue
@@ -1,3 +1,21 @@
+<template>
+  <UiApp
+    :pageUrl="route.fullPath"
+    :pageTitle="pageTitle"
+    :sideBarItems="sideBarItems"
+    :pageNavItems="pageNavItems"
+    :pageTabs="pageTabs"
+    :linkComponent="RouterLink"
+    :isSideNav="true"
+    :widthClass="'w-full'"
+  >
+    <template #navLogo>
+      <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
+    </template>
+    <RouterView />
+  </UiApp>
+</template>
+
 <script setup>
 import { computed } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
@@ -73,21 +91,3 @@ const pageTabs = computed(() => {
 
 const pageTitle = computed(() => route.meta.title || '');
 </script>
-
-<template>
-  <UiApp
-    :pageUrl="route.fullPath"
-    :pageTitle="pageTitle"
-    :sideBarItems="sideBarItems"
-    :pageNavItems="pageNavItems"
-    :pageTabs="pageTabs"
-    :linkComponent="RouterLink"
-    :isSideNav="true"
-    :widthClass="'w-full'"
-  >
-    <template #navLogo>
-      <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
-    </template>
-    <RouterView />
-  </UiApp>
-</template>

--- a/playground/src/layouts/MainLayout.vue
+++ b/playground/src/layouts/MainLayout.vue
@@ -1,14 +1,3 @@
-<script setup>
-import { computed } from 'vue';
-import { useRoute, RouterView } from 'vue-router';
-import UiApp from '@ui/components/App/Index.vue';
-import RouterLink from '../components/RouterLink.vue';
-import { sideBarItems } from '../sideBarItems';
-
-const route = useRoute();
-const pageTitle = computed(() => route.meta.title || '');
-</script>
-
 <template>
   <UiApp
     :pageUrl="route.fullPath"
@@ -24,3 +13,14 @@ const pageTitle = computed(() => route.meta.title || '');
     <RouterView />
   </UiApp>
 </template>
+
+<script setup>
+import { computed } from 'vue';
+import { useRoute, RouterView } from 'vue-router';
+import UiApp from '@ui/components/App/Index.vue';
+import RouterLink from '../components/RouterLink.vue';
+import { sideBarItems } from '../sideBarItems';
+
+const route = useRoute();
+const pageTitle = computed(() => route.meta.title || '');
+</script>

--- a/playground/src/layouts/UserLayout.vue
+++ b/playground/src/layouts/UserLayout.vue
@@ -1,22 +1,3 @@
-<script setup>
-import { useRoute } from 'vue-router';
-import LayoutApp from '@ui/components/App/Index.vue';
-import { Button, useModal } from '@atlas/ui';
-import UserModals from '../components/UserModals.vue';
-import Link from '../components/RouterLink.vue';
-import { sideBarItems } from '../sideBarItems';
-
-const props = defineProps({
-    item: {
-        type: Object,
-        default: () => ({}),
-    },
-});
-
-const { open } = useModal();
-const route = useRoute();
-</script>
-
 <template>
     <LayoutApp
         title="User"
@@ -66,3 +47,22 @@ const route = useRoute();
     </LayoutApp>
     <UserModals />
 </template>
+
+<script setup>
+import { useRoute } from 'vue-router';
+import LayoutApp from '@ui/components/App/Index.vue';
+import { Button, useModal } from '@atlas/ui';
+import UserModals from '../components/UserModals.vue';
+import Link from '../components/RouterLink.vue';
+import { sideBarItems } from '../sideBarItems';
+
+const props = defineProps({
+    item: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+const { open } = useModal();
+const route = useRoute();
+</script>

--- a/playground/src/layouts/UsersLayout.vue
+++ b/playground/src/layouts/UsersLayout.vue
@@ -1,14 +1,3 @@
-<script setup>
-import { computed } from 'vue';
-import { useRoute, RouterView } from 'vue-router';
-import UiApp from '@ui/components/App/Index.vue';
-import RouterLink from '../components/RouterLink.vue';
-import { sideBarItems } from '../sideBarItems';
-
-const route = useRoute();
-const pageTitle = computed(() => route.meta.title || '');
-</script>
-
 <template>
   <UiApp
     :pageUrl="route.fullPath"
@@ -24,3 +13,14 @@ const pageTitle = computed(() => route.meta.title || '');
     <RouterView />
   </UiApp>
 </template>
+
+<script setup>
+import { computed } from 'vue';
+import { useRoute, RouterView } from 'vue-router';
+import UiApp from '@ui/components/App/Index.vue';
+import RouterLink from '../components/RouterLink.vue';
+import { sideBarItems } from '../sideBarItems';
+
+const route = useRoute();
+const pageTitle = computed(() => route.meta.title || '');
+</script>

--- a/playground/src/pages/Users.vue
+++ b/playground/src/pages/Users.vue
@@ -1,3 +1,94 @@
+<template>
+    <LayoutApp
+        title="Users"
+        :pageTitle="`Users (${userTotal})`"
+        containerClass="p-0"
+        :noScroll="true"
+        :sideBarItems="sideBarItems"
+        :linkComponent="Link"
+        :isSideNav="true"
+        :widthClass="'w-full'"
+    >
+        <template #navLogo>
+            <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
+        </template>
+        <template v-if="(selectAll ? userTotal : selected?.length) > 0" #headerTitle>
+            <TableActions
+                :selectedCount="selectAll ? userTotal : selected?.length"
+                :menuItems="tableActionMenuItems"
+                @action="handleTableAction"
+            />
+        </template>
+        <template #headerAction>
+            <div class="flex items-center justify-between">
+                <div class="flex items-center space-x-2">
+                    <InputText
+                        v-model="search"
+                        placeholder="Search user name or email"
+                        class="w-[400px]"
+                        size="small"
+                        clearable
+                    />
+                    <Button size="small" label="Add user" @click="open('ADD_EDIT_USER')" />
+                </div>
+            </div>
+        </template>
+        <template #default>
+            <div class="bg-white dark:bg-surface-800">
+                <Table
+                    :items="users.data"
+                    :itemTotal="userTotal"
+                    :columns="columns"
+                    :sortField="sortField"
+                    :sortOrder="sortOrder"
+                    :selected="selected"
+                    :selectAll="selectAll"
+                    :defaultColumnList="defaultColumnList"
+                    :activeColumnList="viewFields"
+                    hasSelection
+                    hasCustomizeColumns
+                    :scrollOffset="53"
+                    scrollable
+                    @update:selected="selected = $event"
+                    @update:selectAll="selectAll = $event"
+                    @update:activeColumnList="viewFields = $event"
+                    @sort="onSort"
+                >
+                    <template #edit="{ data }">
+                        <div class="w-full flex items-center justify-center">
+                            <ButtonMenu
+                                :items="[
+                                    { label: 'Edit', icon: 'pi pi-pencil', click: () => open('ADD_EDIT_USER', data) },
+                                    { separator: true },
+                                    { label: 'Archive', icon: 'pi pi-trash', click: () => open('DELETE_USER', data) },
+                                ]"
+                            />
+                        </div>
+                    </template>
+                    <template #name="{ data }">
+                        <Link class="hover:underline text-black font-medium" :href="`/users/${data.id}`">
+                            {{ data.name }}
+                        </Link>
+                    </template>
+                </Table>
+            </div>
+        </template>
+        <template #footer>
+            <Select
+                v-model="perPage"
+                :options="perPageOptions"
+                size="small"
+                option-label="label"
+                option-value="value"
+            />
+        </template>
+        <template #footerAction>
+            [placeholder]
+        </template>
+    </LayoutApp>
+    <UserModals />
+</template>
+
 <script setup>
 import { ref, computed } from 'vue';
 import LayoutApp from '@ui/components/App/Index.vue';
@@ -114,94 +205,3 @@ const users = computed(() => ({
 
 const userTotal = computed(() => users.value.total);
 </script>
-
-<template>
-    <LayoutApp
-        title="Users"
-        :pageTitle="`Users (${userTotal})`"
-        containerClass="p-0"
-        :noScroll="true"
-        :sideBarItems="sideBarItems"
-        :linkComponent="Link"
-        :isSideNav="true"
-        :widthClass="'w-full'"
-    >
-        <template #navLogo>
-            <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
-        </template>
-        <template v-if="(selectAll ? userTotal : selected?.length) > 0" #headerTitle>
-            <TableActions
-                :selectedCount="selectAll ? userTotal : selected?.length"
-                :menuItems="tableActionMenuItems"
-                @action="handleTableAction"
-            />
-        </template>
-        <template #headerAction>
-            <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-2">
-                    <InputText
-                        v-model="search"
-                        placeholder="Search user name or email"
-                        class="w-[400px]"
-                        size="small"
-                        clearable
-                    />
-                    <Button size="small" label="Add user" @click="open('ADD_EDIT_USER')" />
-                </div>
-            </div>
-        </template>
-        <template #default>
-            <div class="bg-white dark:bg-surface-800">
-                <Table
-                    :items="users.data"
-                    :itemTotal="userTotal"
-                    :columns="columns"
-                    :sortField="sortField"
-                    :sortOrder="sortOrder"
-                    :selected="selected"
-                    :selectAll="selectAll"
-                    :defaultColumnList="defaultColumnList"
-                    :activeColumnList="viewFields"
-                    hasSelection
-                    hasCustomizeColumns
-                    :scrollOffset="53"
-                    scrollable
-                    @update:selected="selected = $event"
-                    @update:selectAll="selectAll = $event"
-                    @update:activeColumnList="viewFields = $event"
-                    @sort="onSort"
-                >
-                    <template #edit="{ data }">
-                        <div class="w-full flex items-center justify-center">
-                            <ButtonMenu
-                                :items="[
-                                    { label: 'Edit', icon: 'pi pi-pencil', click: () => open('ADD_EDIT_USER', data) },
-                                    { separator: true },
-                                    { label: 'Archive', icon: 'pi pi-trash', click: () => open('DELETE_USER', data) },
-                                ]"
-                            />
-                        </div>
-                    </template>
-                    <template #name="{ data }">
-                        <Link class="hover:underline text-black font-medium" :href="`/users/${data.id}`">
-                            {{ data.name }}
-                        </Link>
-                    </template>
-                </Table>
-            </div>
-        </template>
-        <template #footer>
-            <Select
-                v-model="perPage"
-                :options="perPageOptions"
-                size="small"
-                option-label="label"
-                option-value="value"
-            />
-        </template>
-        <template #footerAction>
-            [placeholder]
-        </template>
-    </LayoutApp>
-    <UserModals />
-</template>

--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -1,3 +1,23 @@
+<template>
+  <section class="space-y-4">
+    <Card v-for="group in groups" :key="group.title">
+      <template #header>
+        <h3 class="text-lg font-semibold">{{ group.title }}</h3>
+      </template>
+      <template #content>
+        <div class="flex flex-wrap gap-4">
+          <Button
+            v-for="state in states"
+            :key="state.label"
+            v-bind="{ ...group.attrs, ...state.attrs }"
+            :label="state.label"
+          />
+        </div>
+      </template>
+    </Card>
+  </section>
+</template>
+
 <script setup>
 import Button from '@ui/components/Button.vue';
 import Card from '@ui/components/Card.vue';
@@ -22,23 +42,3 @@ const states = [
   { label: 'Disabled', attrs: { disabled: true } },
 ];
 </script>
-
-<template>
-  <section class="space-y-4">
-    <Card v-for="group in groups" :key="group.title">
-      <template #header>
-        <h3 class="text-lg font-semibold">{{ group.title }}</h3>
-      </template>
-      <template #content>
-        <div class="flex flex-wrap gap-4">
-          <Button
-            v-for="state in states"
-            :key="state.label"
-            v-bind="{ ...group.attrs, ...state.attrs }"
-            :label="state.label"
-          />
-        </div>
-      </template>
-    </Card>
-  </section>
-</template>

--- a/playground/src/pages/components/Overlays.vue
+++ b/playground/src/pages/components/Overlays.vue
@@ -1,35 +1,3 @@
-<script setup>
-import { ref, reactive } from 'vue';
-import Card from '@ui/components/Card.vue';
-import Button from '@ui/components/Button.vue';
-import Drawer from '@ui/components/Drawer.vue';
-import Dialog from '@ui/components/Dialog.vue';
-import DrawerForm from '@ui/components/DrawerForm.vue';
-import TooltipIcon from '@ui/components/TooltipIcon.vue';
-import LabelField from '@ui/components/LabelField.vue';
-import InputText from '@ui/components/InputText.vue';
-
-const drawerVisible = ref(false);
-const dialogVisible = ref(false);
-const drawerFormVisible = ref(false);
-const form = reactive({
-  id: null,
-  name: null,
-  email: null,
-  processing: false,
-  errors: {},
-});
-
-const openDrawerForm = () => {
-  drawerFormVisible.value = true;
-};
-
-const submitDrawerForm = () => {
-  // no-op for example purposes
-  drawerFormVisible.value = false;
-};
-</script>
-
 <template>
   <section class="space-y-4">
     <Card pt.content="p-0">
@@ -123,3 +91,35 @@ const submitDrawerForm = () => {
     </Card>
   </section>
 </template>
+
+<script setup>
+import { ref, reactive } from 'vue';
+import Card from '@ui/components/Card.vue';
+import Button from '@ui/components/Button.vue';
+import Drawer from '@ui/components/Drawer.vue';
+import Dialog from '@ui/components/Dialog.vue';
+import DrawerForm from '@ui/components/DrawerForm.vue';
+import TooltipIcon from '@ui/components/TooltipIcon.vue';
+import LabelField from '@ui/components/LabelField.vue';
+import InputText from '@ui/components/InputText.vue';
+
+const drawerVisible = ref(false);
+const dialogVisible = ref(false);
+const drawerFormVisible = ref(false);
+const form = reactive({
+  id: null,
+  name: null,
+  email: null,
+  processing: false,
+  errors: {},
+});
+
+const openDrawerForm = () => {
+  drawerFormVisible.value = true;
+};
+
+const submitDrawerForm = () => {
+  // no-op for example purposes
+  drawerFormVisible.value = false;
+};
+</script>

--- a/playground/src/pages/components/Tables.vue
+++ b/playground/src/pages/components/Tables.vue
@@ -1,3 +1,17 @@
+<template>
+  <section class="space-y-4">
+    <Card noPadding>
+      <template #content>
+        <DataTable :value="users" paginator :rows="5">
+          <Column field="name" header="Name" />
+          <Column field="email" header="Email" />
+          <Column field="country" header="Country" />
+        </DataTable>
+      </template>
+    </Card>
+  </section>
+</template>
+
 <script setup>
 import { ref } from 'vue';
 import DataTable from '@ui/components/DataTable.vue';
@@ -15,17 +29,3 @@ const users = ref([
   { name: 'Hank', email: 'hank@example.com', country: 'Japan' },
 ]);
 </script>
-
-<template>
-  <section class="space-y-4">
-    <Card noPadding>
-      <template #content>
-        <DataTable :value="users" paginator :rows="5">
-          <Column field="name" header="Name" />
-          <Column field="email" header="Email" />
-          <Column field="country" header="Country" />
-        </DataTable>
-      </template>
-    </Card>
-  </section>
-</template>

--- a/playground/src/pages/components/Tabs.vue
+++ b/playground/src/pages/components/Tabs.vue
@@ -1,16 +1,3 @@
-<script setup>
-import Card from '@ui/components/Card.vue';
-import Accordion from '@ui/components/Accordion.vue';
-import AccordionPanel from '@ui/components/AccordionPanel.vue';
-import AccordionHeader from '@ui/components/AccordionHeader.vue';
-import AccordionContent from '@ui/components/AccordionContent.vue';
-import Tabs from '@ui/components/Tabs.vue';
-import TabList from '@ui/components/TabList.vue';
-import Tab from '@ui/components/Tab.vue';
-import TabPanels from '@ui/components/TabPanels.vue';
-import TabPanel from '@ui/components/TabPanel.vue';
-</script>
-
 <template>
   <section class="space-y-4">
     <Card noPadding>
@@ -83,3 +70,16 @@ import TabPanel from '@ui/components/TabPanel.vue';
     </Card>
   </section>
 </template>
+
+<script setup>
+import Card from '@ui/components/Card.vue';
+import Accordion from '@ui/components/Accordion.vue';
+import AccordionPanel from '@ui/components/AccordionPanel.vue';
+import AccordionHeader from '@ui/components/AccordionHeader.vue';
+import AccordionContent from '@ui/components/AccordionContent.vue';
+import Tabs from '@ui/components/Tabs.vue';
+import TabList from '@ui/components/TabList.vue';
+import Tab from '@ui/components/Tab.vue';
+import TabPanels from '@ui/components/TabPanels.vue';
+import TabPanel from '@ui/components/TabPanel.vue';
+</script>

--- a/playground/src/pages/components/editor/Index.vue
+++ b/playground/src/pages/components/editor/Index.vue
@@ -1,13 +1,3 @@
-<script setup>
-import { ref } from 'vue';
-import Card from '@ui/components/Card.vue';
-import Editor from '@ui/components/Editor/Index.vue';
-import Content from '@ui/components/Editor/EditorContent.vue';
-import Textarea from '@ui/components/Textarea.vue';
-
-const editContent = ref('');
-</script>
-
 <template>
   <section class="space-y-4">
     <Card>
@@ -44,3 +34,13 @@ const editContent = ref('');
     </Card>
   </section>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+import Card from '@ui/components/Card.vue';
+import Editor from '@ui/components/Editor/Index.vue';
+import Content from '@ui/components/Editor/EditorContent.vue';
+import Textarea from '@ui/components/Textarea.vue';
+
+const editContent = ref('');
+</script>

--- a/playground/src/pages/components/editor/Text.vue
+++ b/playground/src/pages/components/editor/Text.vue
@@ -1,13 +1,3 @@
-<script setup>
-import { ref } from 'vue';
-import Card from '@ui/components/Card.vue';
-import Editor from '@ui/components/Editor/Index.vue';
-import Content from '@ui/components/Editor/EditorContent.vue';
-import Textarea from '@ui/components/Textarea.vue';
-
-const editContent = ref('');
-</script>
-
 <template>
   <section class="space-y-4">
     <Card pt:content:class="p-0">
@@ -27,3 +17,13 @@ const editContent = ref('');
     </Card>
   </section>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+import Card from '@ui/components/Card.vue';
+import Editor from '@ui/components/Editor/Index.vue';
+import Content from '@ui/components/Editor/EditorContent.vue';
+import Textarea from '@ui/components/Textarea.vue';
+
+const editContent = ref('');
+</script>

--- a/playground/src/pages/components/editor/Variant.vue
+++ b/playground/src/pages/components/editor/Variant.vue
@@ -1,14 +1,3 @@
-<script setup>
-import { ref } from 'vue';
-import Card from '@ui/components/Card.vue';
-import Button from '@ui/components/Button.vue';
-import Editor from '@ui/components/Editor/Index.vue';
-import Content from '@ui/components/Editor/EditorContent.vue';
-import Textarea from '@ui/components/Textarea.vue';
-
-const editContent = ref('');
-</script>
-
 <template>
   <section class="space-y-4">
     <Card pt:content:class="p-0">
@@ -51,3 +40,14 @@ const editContent = ref('');
     </Card>
   </section>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+import Card from '@ui/components/Card.vue';
+import Button from '@ui/components/Button.vue';
+import Editor from '@ui/components/Editor/Index.vue';
+import Content from '@ui/components/Editor/EditorContent.vue';
+import Textarea from '@ui/components/Textarea.vue';
+
+const editContent = ref('');
+</script>

--- a/playground/src/pages/components/forms/Errors.vue
+++ b/playground/src/pages/components/forms/Errors.vue
@@ -1,3 +1,62 @@
+<template>
+  <section class="space-y-4">
+    <div class="flex space-x-4">
+      <Card>
+        <template #header>
+          <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center justify-between">
+            <div>Edit (errors)</div>
+            <div class="flex items-center space-x-2">
+              <ToggleSwitch v-model="form.checked" true-value="on" false-value="off" />
+              <ButtonMenu :items="manageItems" />
+            </div>
+          </div>
+        </template>
+        <template #content>
+          <div class="space-y-4 w-full">
+            <div class="w-full flex items-center space-x-4">
+              <LabelField name="first_name" label="First Name" required :error="errors.first_name">
+                <InputText id="first_name_invalid" v-model="form.first_name" type="text" fluid clearable :invalid="true" />
+              </LabelField>
+              <LabelField name="last_name" label="Last Name" required :error="errors.last_name">
+                <InputText id="last_name_invalid" placeholder="Last Name" v-model="form.last_name" type="text" fluid :invalid="true" />
+              </LabelField>
+            </div>
+            <div class="w-full">
+              <LabelField name="gender" label="Gender" :error="errors.gender">
+                <Select v-model="form.gender" showClear :options="genders" optionLabel="gender" optionValue="id" fluid filter :invalid="true" />
+              </LabelField>
+            </div>
+            <div class="w-full">
+              <LabelField name="roles" label="Roles" :error="errors.roles">
+                <MultiSelect v-model="form.roles" showClear :options="roles" optionLabel="name" optionValue="id" fluid filter :invalid="true" />
+              </LabelField>
+            </div>
+            <div class="w-full">
+              <LabelField name="roles" label="Roles (chips)" :error="errors.roles">
+                <MultiSelect v-model="form.roles" display="chip" :options="roles" optionLabel="name" optionValue="id" fluid filter :maxSelectedLabels="6" :invalid="true" />
+              </LabelField>
+            </div>
+            <div class="w-full">
+              <LabelField name="autorole" label="Roles (autocomplete)" :error="errors.autorole">
+                <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear forceSelection :invalid="true" />
+              </LabelField>
+            </div>
+          </div>
+        </template>
+        <template #footer>
+          <div class="space-y-4 w-full">
+            <Errors :errors="errors" />
+            <div class="flex items-center space-x-4">
+              <Button label="Save" @click="open('TEST')" />
+              <Button label="Cancel" variant="text" />
+            </div>
+          </div>
+        </template>
+      </Card>
+    </div>
+  </section>
+</template>
+
 <script setup>
 import { ref, reactive } from 'vue';
 import Card from '@ui/components/Card.vue';
@@ -97,63 +156,3 @@ const search = (event) => {
   }, 250);
 };
 </script>
-
-<template>
-  <section class="space-y-4">
-    <div class="flex space-x-4">
-      <Card>
-        <template #header>
-          <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center justify-between">
-            <div>Edit (errors)</div>
-            <div class="flex items-center space-x-2">
-              <ToggleSwitch v-model="form.checked" true-value="on" false-value="off" />
-              <ButtonMenu :items="manageItems" />
-            </div>
-          </div>
-        </template>
-        <template #content>
-          <div class="space-y-4 w-full">
-            <div class="w-full flex items-center space-x-4">
-              <LabelField name="first_name" label="First Name" required :error="errors.first_name">
-                <InputText id="first_name_invalid" v-model="form.first_name" type="text" fluid clearable :invalid="true" />
-              </LabelField>
-              <LabelField name="last_name" label="Last Name" required :error="errors.last_name">
-                <InputText id="last_name_invalid" placeholder="Last Name" v-model="form.last_name" type="text" fluid :invalid="true" />
-              </LabelField>
-            </div>
-            <div class="w-full">
-              <LabelField name="gender" label="Gender" :error="errors.gender">
-                <Select v-model="form.gender" showClear :options="genders" optionLabel="gender" optionValue="id" fluid filter :invalid="true" />
-              </LabelField>
-            </div>
-            <div class="w-full">
-              <LabelField name="roles" label="Roles" :error="errors.roles">
-                <MultiSelect v-model="form.roles" showClear :options="roles" optionLabel="name" optionValue="id" fluid filter :invalid="true" />
-              </LabelField>
-            </div>
-            <div class="w-full">
-              <LabelField name="roles" label="Roles (chips)" :error="errors.roles">
-                <MultiSelect v-model="form.roles" display="chip" :options="roles" optionLabel="name" optionValue="id" fluid filter :maxSelectedLabels="6" :invalid="true" />
-              </LabelField>
-            </div>
-            <div class="w-full">
-              <LabelField name="autorole" label="Roles (autocomplete)" :error="errors.autorole">
-                <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear forceSelection :invalid="true" />
-              </LabelField>
-            </div>
-          </div>
-        </template>
-        <template #footer>
-          <div class="space-y-4 w-full">
-            <Errors :errors="errors" />
-            <div class="flex items-center space-x-4">
-              <Button label="Save" @click="open('TEST')" />
-              <Button label="Cancel" variant="text" />
-            </div>
-          </div>
-        </template>
-      </Card>
-    </div>
-  </section>
-</template>
-

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -1,111 +1,3 @@
-<script setup>
-import { ref, reactive } from 'vue';
-import Card from '@ui/components/Card.vue';
-import ToggleSwitch from '@ui/components/ToggleSwitch.vue';
-import Button from '@ui/components/Button.vue';
-import ButtonMenu from '@ui/components/ButtonMenu.vue';
-import LabelField from '@ui/components/LabelField.vue';
-import InputText from '@ui/components/InputText.vue';
-import Select from '@ui/components/Select.vue';
-import MultiSelect from '@ui/components/MultiSelect.vue';
-import AutoComplete from '@ui/components/AutoComplete.vue';
-import InputNumber from '@ui/components/InputNumber.vue';
-import Alert from '@ui/components/Alert.vue';
-import LabelCheckbox from '@ui/components/LabelCheckbox.vue';
-import LabelRadioButton from '@ui/components/LabelRadioButton.vue';
-import TooltipInfo from '@ui/components/TooltipInfo.vue';
-import { useModal } from '@ui/composables';
-
-const { open } = useModal();
-
-const form = reactive({
-    first_name: 'John',
-    last_name: null,
-    amount: null,
-    email: 'example@example.com',
-    roles: [],
-    type: 'credit',
-    payment: 'disabled',
-    agree: false,
-    checked: 'on',
-    gender: null,
-    autorole: null,
-});
-
-const roles = ref([
-    { id: 'admin', name: 'Admin' },
-    { id: 'user', name: 'User' },
-    { id: 'guest', name: 'Guest' },
-    { id: 'banned', name: 'Banned' },
-    { id: 'pending', name: 'Pending' },
-    { id: 'suspended', name: 'Suspended' },
-    { id: 'deleted', name: 'Deleted' },
-    { id: 'blacklisted', name: 'Blacklisted' },
-    { id: 'archived', name: 'Archived' },
-]);
-
-const genders = ref([
-    { id: 'male', gender: 'Male' },
-    { id: 'female', gender: 'Female' },
-    { id: 'other', gender: 'Other' },
-]);
-
-const autoRoles = ref([
-    { id: 'admin', label: 'Admin' },
-    { id: 'user', label: 'User' },
-    { id: 'guest', label: 'Guest' },
-    { id: 'banned', label: 'Banned' },
-    { id: 'pending', label: 'Pending' },
-    { id: 'suspended', label: 'Suspended' },
-    { id: 'deleted', label: 'Deleted' },
-    { id: 'blacklisted', label: 'Blacklisted' },
-    { id: 'archived', label: 'Archived' },
-]);
-
-const types = ref([
-    { id: 'credit', name: 'Credit' },
-    { id: 'debit', name: 'Debit' },
-    { id: 'transfer', name: 'Transfer' },
-    { id: 'deposit', name: 'Deposit' },
-]);
-
-const manageItems = [
-    {
-        label: 'Edit',
-        icon: 'text-sm pi pi-pencil',
-        action: 'edit'
-    },
-    {
-        label: 'Download',
-        icon: 'text-sm pi pi-download',
-        action: 'download',
-        disabled: true
-    },
-    {
-        separator: true
-    },
-    {
-        label: 'Archive',
-        icon: 'text-sm pi pi-trash',
-        action: 'delete'
-    }
-];
-
-const filteredRoles = ref([...autoRoles.value]);
-
-const search = (event) => {
-    setTimeout(() => {
-        if (!event.query.trim().length) {
-            filteredRoles.value = [...autoRoles.value];
-        } else {
-            filteredRoles.value = autoRoles.value.filter((country) => {
-                return country.label.toLowerCase().startsWith(event.query.toLowerCase());
-            });
-        }
-    }, 250);
-};
-</script>
-
 <template>
   <section class="space-y-4">
     <div class="flex flex-col space-y-4">
@@ -304,3 +196,110 @@ const search = (event) => {
   </section>
 </template>
 
+<script setup>
+import { ref, reactive } from 'vue';
+import Card from '@ui/components/Card.vue';
+import ToggleSwitch from '@ui/components/ToggleSwitch.vue';
+import Button from '@ui/components/Button.vue';
+import ButtonMenu from '@ui/components/ButtonMenu.vue';
+import LabelField from '@ui/components/LabelField.vue';
+import InputText from '@ui/components/InputText.vue';
+import Select from '@ui/components/Select.vue';
+import MultiSelect from '@ui/components/MultiSelect.vue';
+import AutoComplete from '@ui/components/AutoComplete.vue';
+import InputNumber from '@ui/components/InputNumber.vue';
+import Alert from '@ui/components/Alert.vue';
+import LabelCheckbox from '@ui/components/LabelCheckbox.vue';
+import LabelRadioButton from '@ui/components/LabelRadioButton.vue';
+import TooltipInfo from '@ui/components/TooltipInfo.vue';
+import { useModal } from '@ui/composables';
+
+const { open } = useModal();
+
+const form = reactive({
+    first_name: 'John',
+    last_name: null,
+    amount: null,
+    email: 'example@example.com',
+    roles: [],
+    type: 'credit',
+    payment: 'disabled',
+    agree: false,
+    checked: 'on',
+    gender: null,
+    autorole: null,
+});
+
+const roles = ref([
+    { id: 'admin', name: 'Admin' },
+    { id: 'user', name: 'User' },
+    { id: 'guest', name: 'Guest' },
+    { id: 'banned', name: 'Banned' },
+    { id: 'pending', name: 'Pending' },
+    { id: 'suspended', name: 'Suspended' },
+    { id: 'deleted', name: 'Deleted' },
+    { id: 'blacklisted', name: 'Blacklisted' },
+    { id: 'archived', name: 'Archived' },
+]);
+
+const genders = ref([
+    { id: 'male', gender: 'Male' },
+    { id: 'female', gender: 'Female' },
+    { id: 'other', gender: 'Other' },
+]);
+
+const autoRoles = ref([
+    { id: 'admin', label: 'Admin' },
+    { id: 'user', label: 'User' },
+    { id: 'guest', label: 'Guest' },
+    { id: 'banned', label: 'Banned' },
+    { id: 'pending', label: 'Pending' },
+    { id: 'suspended', label: 'Suspended' },
+    { id: 'deleted', label: 'Deleted' },
+    { id: 'blacklisted', label: 'Blacklisted' },
+    { id: 'archived', label: 'Archived' },
+]);
+
+const types = ref([
+    { id: 'credit', name: 'Credit' },
+    { id: 'debit', name: 'Debit' },
+    { id: 'transfer', name: 'Transfer' },
+    { id: 'deposit', name: 'Deposit' },
+]);
+
+const manageItems = [
+    {
+        label: 'Edit',
+        icon: 'text-sm pi pi-pencil',
+        action: 'edit'
+    },
+    {
+        label: 'Download',
+        icon: 'text-sm pi pi-download',
+        action: 'download',
+        disabled: true
+    },
+    {
+        separator: true
+    },
+    {
+        label: 'Archive',
+        icon: 'text-sm pi pi-trash',
+        action: 'delete'
+    }
+];
+
+const filteredRoles = ref([...autoRoles.value]);
+
+const search = (event) => {
+    setTimeout(() => {
+        if (!event.query.trim().length) {
+            filteredRoles.value = [...autoRoles.value];
+        } else {
+            filteredRoles.value = autoRoles.value.filter((country) => {
+                return country.label.toLowerCase().startsWith(event.query.toLowerCase());
+            });
+        }
+    }, 250);
+};
+</script>

--- a/playground/src/pages/components/forms/Sizing.vue
+++ b/playground/src/pages/components/forms/Sizing.vue
@@ -1,3 +1,75 @@
+<template>
+  <section class="space-y-4">
+    <Card v-for="item in formSizes" :key="item.label" class="w-full">
+      <template #header>
+        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center">
+          {{ item.label }}
+        </div>
+      </template>
+      <template #content>
+        <div class="space-y-4">
+          <div class="flex items-end space-x-4">
+            <InputText v-model="form.query" fluid :size="item.size" class="flex-1" />
+            <Button label="Search" :size="item.size" />
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <LabelField name="first_name" label="First Name">
+              <InputText v-model="form.first_name" fluid :size="item.size" />
+            </LabelField>
+            <LabelField name="last_name" label="Last Name">
+              <InputText v-model="form.last_name" fluid :size="item.size" />
+            </LabelField>
+            <LabelField name="email" label="Email">
+              <InputText v-model="form.email" fluid :size="item.size" />
+            </LabelField>
+            <LabelField name="type" label="Type">
+              <Select v-model="form.type" :options="types" optionLabel="name" optionValue="id" fluid :size="item.size" />
+            </LabelField>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <LabelField name="amount" label="Amount">
+              <InputNumber
+                v-model="form.amount"
+                mode="currency"
+                currency="USD"
+                locale="en-US"
+                fluid
+                placeholder="$0.00"
+                :size="item.size"
+              />
+            </LabelField>
+            <LabelField name="roles" label="Roles">
+              <MultiSelect v-model="form.roles" :options="roles" optionLabel="name" optionValue="id" fluid :size="item.size" />
+            </LabelField>
+            <LabelField name="autorole" label="Auto Role">
+              <AutoComplete
+                v-model="form.autorole"
+                :suggestions="filteredRoles"
+                @complete="search"
+                optionLabel="label"
+                optionValue="id"
+                fluid
+                dropdown
+                showClear
+                :size="item.size"
+              />
+            </LabelField>
+            <LabelField name="gender" label="Gender">
+              <Select v-model="form.gender" :options="genders" optionLabel="gender" optionValue="id" fluid :size="item.size" />
+            </LabelField>
+          </div>
+        </div>
+      </template>
+      <template #footer>
+        <div class="flex items-center space-x-4">
+          <Button label="Save" :size="item.size" />
+          <Button label="Cancel" text :size="item.size" />
+        </div>
+      </template>
+    </Card>
+  </section>
+</template>
+
 <script setup>
 import { ref, reactive } from 'vue';
 import Card from '@ui/components/Card.vue';
@@ -81,75 +153,3 @@ const search = (event) => {
   }, 250);
 };
 </script>
-
-<template>
-  <section class="space-y-4">
-    <Card v-for="item in formSizes" :key="item.label" class="w-full">
-      <template #header>
-        <div class="font-semibold text-gray-900 dark:text-gray-100 text-md flex items-center">
-          {{ item.label }}
-        </div>
-      </template>
-      <template #content>
-        <div class="space-y-4">
-          <div class="flex items-end space-x-4">
-            <InputText v-model="form.query" fluid :size="item.size" class="flex-1" />
-            <Button label="Search" :size="item.size" />
-          </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            <LabelField name="first_name" label="First Name">
-              <InputText v-model="form.first_name" fluid :size="item.size" />
-            </LabelField>
-            <LabelField name="last_name" label="Last Name">
-              <InputText v-model="form.last_name" fluid :size="item.size" />
-            </LabelField>
-            <LabelField name="email" label="Email">
-              <InputText v-model="form.email" fluid :size="item.size" />
-            </LabelField>
-            <LabelField name="type" label="Type">
-              <Select v-model="form.type" :options="types" optionLabel="name" optionValue="id" fluid :size="item.size" />
-            </LabelField>
-          </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            <LabelField name="amount" label="Amount">
-              <InputNumber
-                v-model="form.amount"
-                mode="currency"
-                currency="USD"
-                locale="en-US"
-                fluid
-                placeholder="$0.00"
-                :size="item.size"
-              />
-            </LabelField>
-            <LabelField name="roles" label="Roles">
-              <MultiSelect v-model="form.roles" :options="roles" optionLabel="name" optionValue="id" fluid :size="item.size" />
-            </LabelField>
-            <LabelField name="autorole" label="Auto Role">
-              <AutoComplete
-                v-model="form.autorole"
-                :suggestions="filteredRoles"
-                @complete="search"
-                optionLabel="label"
-                optionValue="id"
-                fluid
-                dropdown
-                showClear
-                :size="item.size"
-              />
-            </LabelField>
-            <LabelField name="gender" label="Gender">
-              <Select v-model="form.gender" :options="genders" optionLabel="gender" optionValue="id" fluid :size="item.size" />
-            </LabelField>
-          </div>
-        </div>
-      </template>
-      <template #footer>
-        <div class="flex items-center space-x-4">
-          <Button label="Save" :size="item.size" />
-          <Button label="Cancel" text :size="item.size" />
-        </div>
-      </template>
-    </Card>
-  </section>
-</template>


### PR DESCRIPTION
## Summary
- move script blocks after templates across playground Vue components
- document template-script-style order in AGENTS instructions

## Testing
- `cd ui && npm test`
- `cd playground && npm test` *(fails: Missing script "test")*
- `cd laravel && composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab0487e8888325b31debb670bb76ef