### PR TITLE
docs: clarify repo purpose and coding guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,37 @@
 # Agent Instructions
 
-Welcome to the **Atlas** monorepo. This file provides high-level guidance for contributors.
-It will grow as the project evolves.
-
-All contributions must follow the architecture and coding conventions outlined in the guides below.
+Atlas is a collection of reusable Laravel packages and Vue 3 UI components
+that consumers can drop into their own applications. This file summarizes the
+coding conventions and expectations for contributors.
 
 ## Where things live
 - `laravel/`: base Laravel framework package.
-- `ui/`: reusable Vue 3 UI components.
+- `ui/`: reusable Vue 3 component library.
+- `playground/`: Vite + Vue sandbox for manual UI testing.
 - `docs/`: architecture and convention references.
 
-## Conventions
-- Adhere to the architecture and coding standards in [docs/backend-guide.md](docs/backend-guide.md).
-- Front-end architecture and patterns are covered in [docs/frontend-guide.md](docs/frontend-guide.md).
-- In Vue single-file components, always order blocks as `<template>`, then `<script>`, and finally `<style>`.
+## Coding guidelines
+
+### Laravel / PHP
+- Follow the architecture and rules in [docs/backend-guide.md](docs/backend-guide.md).
+- Use PHP 8+ features with strict types and typed properties.
+- Follow PSR-12 formatting (enforced via Laravel Pint).
+- Keep controllers thin; business logic belongs in service classes.
+- Write tests for new features and run `composer test` before committing.
+
+### Vue / JS
+- Follow [docs/frontend-guide.md](docs/frontend-guide.md).
+- Use the Composition API with `<script setup>` syntax.
+- Order Vue SFC blocks as `<template>`, then `<script>`, then `<style>`.
+- Components are presentational; extract logic to composables or services.
+- PascalCase components, camelCase composables and utils.
+- Run `npm test` for any changes affecting the UI package.
 - UI docs:
   - [Composables](docs/ui/composables.md)
   - [Utils](docs/ui/utils.md)
-- When updating UI documentation that discusses a component's API, link to the corresponding PrimeVue API. If PrimeVue lacks an API page, document the component's API details so consumers understand how to use it.
+- When updating UI documentation that covers a component API, link to the
+  corresponding PrimeVue docs. If no page exists, document the API yourself so
+  consumers understand how to use it.
 
 ## Testing
 - Run front-end tests with `npm test` inside `ui/`.
@@ -26,3 +40,4 @@ All contributions must follow the architecture and coding conventions outlined i
 ## Pull requests
 - Keep commits focused and reference relevant documentation when introducing new patterns.
 - Update this file and other docs as conventions evolve.
+


### PR DESCRIPTION
## Summary
- clarify that Atlas packages are reusable building blocks for consumer projects
- document Laravel/PHP and Vue/JS coding guidelines
- mention playground directory in agent instructions

## Testing
- `npm test` (ui)
- `composer test` (laravel) *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab0730f8648325bde042261d1e4c3f