### PR TITLE
refactor(playground): replace @ui imports

### DIFF
--- a/playground/src/layouts/ComponentsLayout.vue
+++ b/playground/src/layouts/ComponentsLayout.vue
@@ -19,7 +19,7 @@
 <script setup>
 import { computed } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
-import UiApp from '@ui/components/App/Index.vue';
+import UiApp from '@atlas/ui/components/App/Index.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 

--- a/playground/src/layouts/MainLayout.vue
+++ b/playground/src/layouts/MainLayout.vue
@@ -17,7 +17,7 @@
 <script setup>
 import { computed } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
-import UiApp from '@ui/components/App/Index.vue';
+import UiApp from '@atlas/ui/components/App/Index.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 

--- a/playground/src/layouts/UserLayout.vue
+++ b/playground/src/layouts/UserLayout.vue
@@ -50,7 +50,7 @@
 
 <script setup>
 import { useRoute } from 'vue-router';
-import LayoutApp from '@ui/components/App/Index.vue';
+import LayoutApp from '@atlas/ui/components/App/Index.vue';
 import { Button, useModal } from '@atlas/ui';
 import UserModals from '../components/UserModals.vue';
 import Link from '../components/RouterLink.vue';

--- a/playground/src/layouts/UsersLayout.vue
+++ b/playground/src/layouts/UsersLayout.vue
@@ -17,7 +17,7 @@
 <script setup>
 import { computed } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
-import UiApp from '@ui/components/App/Index.vue';
+import UiApp from '@atlas/ui/components/App/Index.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 

--- a/playground/src/pages/Users.vue
+++ b/playground/src/pages/Users.vue
@@ -93,7 +93,7 @@
 
 <script setup>
 import { ref, computed } from 'vue';
-import LayoutApp from '@ui/components/App/Index.vue';
+import LayoutApp from '@atlas/ui/components/App/Index.vue';
 import { Table, ButtonMenu, TableActions, InputText, Button, Select, useModal } from '@atlas/ui';
 import UserModals from '../components/UserModals.vue';
 import Link from '../components/RouterLink.vue';

--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -19,8 +19,8 @@
 </template>
 
 <script setup>
-import Button from '@ui/components/Button.vue';
-import Card from '@ui/components/Card.vue';
+import Button from '@atlas/ui/components/Button.vue';
+import Card from '@atlas/ui/components/Card.vue';
 
 const groups = [
   { title: 'Buttons (regular)', attrs: {} },

--- a/playground/src/pages/components/Overlays.vue
+++ b/playground/src/pages/components/Overlays.vue
@@ -94,14 +94,14 @@
 
 <script setup>
 import { ref, reactive } from 'vue';
-import Card from '@ui/components/Card.vue';
-import Button from '@ui/components/Button.vue';
-import Drawer from '@ui/components/Drawer.vue';
-import Dialog from '@ui/components/Dialog.vue';
-import DrawerForm from '@ui/components/DrawerForm.vue';
-import TooltipIcon from '@ui/components/TooltipIcon.vue';
-import LabelField from '@ui/components/LabelField.vue';
-import InputText from '@ui/components/InputText.vue';
+import Card from '@atlas/ui/components/Card.vue';
+import Button from '@atlas/ui/components/Button.vue';
+import Drawer from '@atlas/ui/components/Drawer.vue';
+import Dialog from '@atlas/ui/components/Dialog.vue';
+import DrawerForm from '@atlas/ui/components/DrawerForm.vue';
+import TooltipIcon from '@atlas/ui/components/TooltipIcon.vue';
+import LabelField from '@atlas/ui/components/LabelField.vue';
+import InputText from '@atlas/ui/components/InputText.vue';
 
 const drawerVisible = ref(false);
 const dialogVisible = ref(false);

--- a/playground/src/pages/components/Tables.vue
+++ b/playground/src/pages/components/Tables.vue
@@ -14,9 +14,9 @@
 
 <script setup>
 import { ref } from 'vue';
-import DataTable from '@ui/components/DataTable.vue';
+import DataTable from '@atlas/ui/components/DataTable.vue';
 import Column from 'primevue/column';
-import Card from '@ui/components/Card.vue';
+import Card from '@atlas/ui/components/Card.vue';
 
 const users = ref([
   { name: 'Alice', email: 'alice@example.com', country: 'USA' },

--- a/playground/src/pages/components/Tabs.vue
+++ b/playground/src/pages/components/Tabs.vue
@@ -72,14 +72,14 @@
 </template>
 
 <script setup>
-import Card from '@ui/components/Card.vue';
-import Accordion from '@ui/components/Accordion.vue';
-import AccordionPanel from '@ui/components/AccordionPanel.vue';
-import AccordionHeader from '@ui/components/AccordionHeader.vue';
-import AccordionContent from '@ui/components/AccordionContent.vue';
-import Tabs from '@ui/components/Tabs.vue';
-import TabList from '@ui/components/TabList.vue';
-import Tab from '@ui/components/Tab.vue';
-import TabPanels from '@ui/components/TabPanels.vue';
-import TabPanel from '@ui/components/TabPanel.vue';
+import Card from '@atlas/ui/components/Card.vue';
+import Accordion from '@atlas/ui/components/Accordion.vue';
+import AccordionPanel from '@atlas/ui/components/AccordionPanel.vue';
+import AccordionHeader from '@atlas/ui/components/AccordionHeader.vue';
+import AccordionContent from '@atlas/ui/components/AccordionContent.vue';
+import Tabs from '@atlas/ui/components/Tabs.vue';
+import TabList from '@atlas/ui/components/TabList.vue';
+import Tab from '@atlas/ui/components/Tab.vue';
+import TabPanels from '@atlas/ui/components/TabPanels.vue';
+import TabPanel from '@atlas/ui/components/TabPanel.vue';
 </script>

--- a/playground/src/pages/components/editor/Index.vue
+++ b/playground/src/pages/components/editor/Index.vue
@@ -37,10 +37,10 @@
 
 <script setup>
 import { ref } from 'vue';
-import Card from '@ui/components/Card.vue';
-import Editor from '@ui/components/Editor/Index.vue';
-import Content from '@ui/components/Editor/EditorContent.vue';
-import Textarea from '@ui/components/Textarea.vue';
+import Card from '@atlas/ui/components/Card.vue';
+import Editor from '@atlas/ui/components/Editor/Index.vue';
+import Content from '@atlas/ui/components/Editor/EditorContent.vue';
+import Textarea from '@atlas/ui/components/Textarea.vue';
 
 const editContent = ref('');
 </script>

--- a/playground/src/pages/components/editor/Text.vue
+++ b/playground/src/pages/components/editor/Text.vue
@@ -20,10 +20,10 @@
 
 <script setup>
 import { ref } from 'vue';
-import Card from '@ui/components/Card.vue';
-import Editor from '@ui/components/Editor/Index.vue';
-import Content from '@ui/components/Editor/EditorContent.vue';
-import Textarea from '@ui/components/Textarea.vue';
+import Card from '@atlas/ui/components/Card.vue';
+import Editor from '@atlas/ui/components/Editor/Index.vue';
+import Content from '@atlas/ui/components/Editor/EditorContent.vue';
+import Textarea from '@atlas/ui/components/Textarea.vue';
 
 const editContent = ref('');
 </script>

--- a/playground/src/pages/components/editor/Variant.vue
+++ b/playground/src/pages/components/editor/Variant.vue
@@ -43,11 +43,11 @@
 
 <script setup>
 import { ref } from 'vue';
-import Card from '@ui/components/Card.vue';
-import Button from '@ui/components/Button.vue';
-import Editor from '@ui/components/Editor/Index.vue';
-import Content from '@ui/components/Editor/EditorContent.vue';
-import Textarea from '@ui/components/Textarea.vue';
+import Card from '@atlas/ui/components/Card.vue';
+import Button from '@atlas/ui/components/Button.vue';
+import Editor from '@atlas/ui/components/Editor/Index.vue';
+import Content from '@atlas/ui/components/Editor/EditorContent.vue';
+import Textarea from '@atlas/ui/components/Textarea.vue';
 
 const editContent = ref('');
 </script>

--- a/playground/src/pages/components/forms/Errors.vue
+++ b/playground/src/pages/components/forms/Errors.vue
@@ -59,17 +59,17 @@
 
 <script setup>
 import { ref, reactive } from 'vue';
-import Card from '@ui/components/Card.vue';
-import ToggleSwitch from '@ui/components/ToggleSwitch.vue';
-import Button from '@ui/components/Button.vue';
-import ButtonMenu from '@ui/components/ButtonMenu.vue';
-import LabelField from '@ui/components/LabelField.vue';
-import InputText from '@ui/components/InputText.vue';
-import Select from '@ui/components/Select.vue';
-import MultiSelect from '@ui/components/MultiSelect.vue';
-import AutoComplete from '@ui/components/AutoComplete.vue';
-import { useModal } from '@ui/composables';
-import Errors from '@ui/components/Errors.vue';
+import Card from '@atlas/ui/components/Card.vue';
+import ToggleSwitch from '@atlas/ui/components/ToggleSwitch.vue';
+import Button from '@atlas/ui/components/Button.vue';
+import ButtonMenu from '@atlas/ui/components/ButtonMenu.vue';
+import LabelField from '@atlas/ui/components/LabelField.vue';
+import InputText from '@atlas/ui/components/InputText.vue';
+import Select from '@atlas/ui/components/Select.vue';
+import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
+import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
+import { useModal } from '@atlas/ui/composables';
+import Errors from '@atlas/ui/components/Errors.vue';
 
 const { open } = useModal();
 

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -198,21 +198,21 @@
 
 <script setup>
 import { ref, reactive } from 'vue';
-import Card from '@ui/components/Card.vue';
-import ToggleSwitch from '@ui/components/ToggleSwitch.vue';
-import Button from '@ui/components/Button.vue';
-import ButtonMenu from '@ui/components/ButtonMenu.vue';
-import LabelField from '@ui/components/LabelField.vue';
-import InputText from '@ui/components/InputText.vue';
-import Select from '@ui/components/Select.vue';
-import MultiSelect from '@ui/components/MultiSelect.vue';
-import AutoComplete from '@ui/components/AutoComplete.vue';
-import InputNumber from '@ui/components/InputNumber.vue';
-import Alert from '@ui/components/Alert.vue';
-import LabelCheckbox from '@ui/components/LabelCheckbox.vue';
-import LabelRadioButton from '@ui/components/LabelRadioButton.vue';
-import TooltipInfo from '@ui/components/TooltipInfo.vue';
-import { useModal } from '@ui/composables';
+import Card from '@atlas/ui/components/Card.vue';
+import ToggleSwitch from '@atlas/ui/components/ToggleSwitch.vue';
+import Button from '@atlas/ui/components/Button.vue';
+import ButtonMenu from '@atlas/ui/components/ButtonMenu.vue';
+import LabelField from '@atlas/ui/components/LabelField.vue';
+import InputText from '@atlas/ui/components/InputText.vue';
+import Select from '@atlas/ui/components/Select.vue';
+import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
+import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
+import InputNumber from '@atlas/ui/components/InputNumber.vue';
+import Alert from '@atlas/ui/components/Alert.vue';
+import LabelCheckbox from '@atlas/ui/components/LabelCheckbox.vue';
+import LabelRadioButton from '@atlas/ui/components/LabelRadioButton.vue';
+import TooltipInfo from '@atlas/ui/components/TooltipInfo.vue';
+import { useModal } from '@atlas/ui/composables';
 
 const { open } = useModal();
 

--- a/playground/src/pages/components/forms/Sizing.vue
+++ b/playground/src/pages/components/forms/Sizing.vue
@@ -72,14 +72,14 @@
 
 <script setup>
 import { ref, reactive } from 'vue';
-import Card from '@ui/components/Card.vue';
-import LabelField from '@ui/components/LabelField.vue';
-import InputText from '@ui/components/InputText.vue';
-import Select from '@ui/components/Select.vue';
-import MultiSelect from '@ui/components/MultiSelect.vue';
-import AutoComplete from '@ui/components/AutoComplete.vue';
-import InputNumber from '@ui/components/InputNumber.vue';
-import Button from '@ui/components/Button.vue';
+import Card from '@atlas/ui/components/Card.vue';
+import LabelField from '@atlas/ui/components/LabelField.vue';
+import InputText from '@atlas/ui/components/InputText.vue';
+import Select from '@atlas/ui/components/Select.vue';
+import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
+import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
+import InputNumber from '@atlas/ui/components/InputNumber.vue';
+import Button from '@atlas/ui/components/Button.vue';
 
 const form = reactive({
   first_name: 'John',

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -9,7 +9,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@atlas/ui': path.resolve(__dirname, '../ui/src'),
-      '@ui': path.resolve(__dirname, '../ui/src'),
       '@inertiajs/vue3': path.resolve(__dirname, './src/inertia.js')
     }
   },


### PR DESCRIPTION
## Summary
- use `@atlas/ui` in playground components
- drop `@ui` alias from Vite config

## Testing
- `npm test` in `ui`
- `composer test` in `laravel`


------
https://chatgpt.com/codex/tasks/task_b_68ab082334b4832595e05788755e71f5