### PR TITLE
Fix UserModals reactive initialization

### DIFF
--- a/playground/src/components/UserModals.vue
+++ b/playground/src/components/UserModals.vue
@@ -31,7 +31,6 @@ const { activeState, data, close } = useModal();
 const addEditUserVisible = activeState('ADD_EDIT_USER');
 const deleteUserVisible = activeState('DELETE_USER');
 const addEditUserData = data('ADD_EDIT_USER');
-const deleteUserData = data('DELETE_USER');
 
 const form = reactive({
   id: null,
@@ -43,6 +42,7 @@ const form = reactive({
 
 watch(addEditUserVisible, (visible) => {
   if (visible) {
+    const user = addEditUserData.value || {};
     form.id = user.id ?? null;
     form.name = user.name ?? '';
     form.email = user.email ?? '';


### PR DESCRIPTION
## Summary
- initialize add/edit user form with the current modal data when modal opens
- clean up unused delete modal data reference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab09a575ac83258dd7754413f8c98b