### PR TITLE
docs: clarify atlas ui imports

### DIFF
--- a/docs/laravel/inertia-data-table-options.md
+++ b/docs/laravel/inertia-data-table-options.md
@@ -56,7 +56,7 @@ Pass the resolved `$options` to your Inertia view. On the client side, the [`use
 
 ```vue
 <script setup>
-import { useDataTableOptions } from '@tmarois/atlas';
+import { useDataTableOptions } from '@atlas/ui';
 import { usePage } from '@inertiajs/vue3';
 
 const { props } = usePage();
@@ -82,7 +82,7 @@ new requests whenever a filter changes.
 </template>
 
 <script setup>
-import { useDataTableOptions } from '@tmarois/atlas';
+import { useDataTableOptions } from '@atlas/ui';
 import { usePage } from '@inertiajs/vue3';
 
 const { props } = usePage();

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -82,7 +82,7 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      '@atlas/ui': path.resolve(__dirname, 'node_modules/@atlas/ui'),
+      '@atlas/ui': path.resolve(__dirname, 'node_modules/@tmarois/atlas-ui'),
     },
   },
 });

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -2,9 +2,11 @@
 
 Reusable Vue 3 components styled with Tailwind CSS and built on top of PrimeVue.
 
+See the [App Layout](ui/app.md) for a ready-to-use application wrapper.
+
 ## Table of Contents
+- [Setup](#setup)
 - [Component Guide](ui/component-guide.md)
-- [Application](#application)
 - [Override Themes with Passthrough](#override-themes-with-passthrough)
 - [Components](#components)
   - [Actions](#actions)
@@ -61,16 +63,42 @@ Reusable Vue 3 components styled with Tailwind CSS and built on top of PrimeVue.
     - [Paginator](#paginator)
     - [Pagination](#pagination)
   - [Feedback](#feedback)
-    - [Alert](#alert)
-    - [Errors](#errors)
-    - [Toast](#toast)
-    - [ProgressBar](#progressbar)
+  - [Alert](#alert)
+  - [Errors](#errors)
+  - [Toast](#toast)
+  - [ProgressBar](#progressbar)
+
+## Setup
+
+Configure your build tool to resolve the `@atlas/ui` alias to the package. With Vite:
+
+```js
+// vite.config.js
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@atlas/ui': path.resolve(__dirname, 'node_modules/@atlas/ui'),
+    },
+  },
+});
+```
+
+If you're using another bundler, configure an equivalent alias so `@atlas/ui` points to the package.
 
 ## Override Themes with Passthrough
 
 PrimeVue components support a [passthrough (pt) API](https://primevue.org/passthrough/) that lets you customize internal elements and classes. Atlas forwards this API so you can tweak component styles or structure when needed.
 
 ### Example: Button
+
+```ts
+import { Button } from '@atlas/ui';
+```
 
 ```vue
 <Button
@@ -81,10 +109,6 @@ PrimeVue components support a [passthrough (pt) API](https://primevue.org/passth
   }"
 />
 ```
-
-## Application
-
-See the [Application UI guide](ui/application.md) for the app's page structure and layout and the [App Layout](ui/app.md) component for a ready-to-use page wrapper.
 
 ## Components
 

--- a/docs/ui/composables.md
+++ b/docs/ui/composables.md
@@ -16,7 +16,7 @@ The `useDataTableOptions` composable keeps datatable query options in sync with 
 
 ```vue
 <script setup>
-import { useDataTableOptions } from '@tmarois/atlas';
+import { useDataTableOptions } from '@atlas/ui';
 import { usePage } from '@inertiajs/vue3';
 
 const { props } = usePage();
@@ -38,7 +38,7 @@ The `useModal` composable provides a flexible modal management system for Vue ap
 ### Basic Usage
 
 ```typescript
-import { useModal } from '@tmarois/atlas';
+import { useModal } from '@atlas/ui';
 
 const modal = useModal();
 
@@ -80,7 +80,7 @@ const modalData = modal.data('confirmDialog');
 </template>
 
 <script setup>
-import { useModal } from '@tmarois/atlas';
+import { useModal } from '@atlas/ui';
 
 const modal = useModal();
 const isActive = modal.activeState('confirmDialog');
@@ -91,7 +91,7 @@ const isActive = modal.activeState('confirmDialog');
 
 ```js
 <script setup>
-import { useModal } from '@tmarois/atlas';
+import { useModal } from '@atlas/ui';
 
 const modal = useModal();
 
@@ -115,7 +115,7 @@ The `useScroll` composable provides utilities for scroll management and detectio
 
 ```js
 <script setup>
-import { useScroll } from '@tmarois/atlas';
+import { useScroll } from '@atlas/ui';
 import { ref } from 'vue';
 
 const elementRef = ref(null);
@@ -162,7 +162,7 @@ onUnmounted(() => {
 
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue';
-import { useScroll } from '@tmarois/atlas';
+import { useScroll } from '@atlas/ui';
 
 const containerRef = ref(null);
 const scroll = useScroll('container');
@@ -184,7 +184,7 @@ onUnmounted(() => {
 
 ```js
 <script setup>
-import { useModal, useScroll } from '@tmarois/atlas';
+import { useModal, useScroll } from '@atlas/ui';
 
 const modal = useModal();
 const scroll = useScroll('modal');

--- a/docs/ui/utils.md
+++ b/docs/ui/utils.md
@@ -39,7 +39,7 @@ Converts a number of bytes into a human-readable file size string.
 
 **Example:**
 ```typescript
-import { formatBytes } from '@tmarois/atlas';
+import { formatBytes } from '@atlas/ui';
 
 formatBytes(1024);        // '1.00 KB'
 formatBytes(1536, 1);     // '1.5 KB'
@@ -60,7 +60,7 @@ Formats a date string or Date object into a localized date string.
 
 **Example:**
 ```typescript
-import { formatDate } from '@tmarois/atlas';
+import { formatDate } from '@atlas/ui';
 
 formatDate('2023-01-15T12:00:00');                  // '1/15/2023'
 formatDate('2023-01-15T12:00:00', 'America/New_York'); // '1/15/2023'
@@ -80,7 +80,7 @@ Formats a date string or Date object into a localized date and time string.
 
 **Example:**
 ```typescript
-import { formatDatetime } from '@tmarois/atlas';
+import { formatDatetime } from '@atlas/ui';
 
 formatDatetime('2023-01-15T12:00:00');                  // '1/15/2023, 12:00 PM'
 formatDatetime('2023-01-15T12:00:00', 'America/New_York'); // '1/15/2023, 7:00 AM'
@@ -98,7 +98,7 @@ Converts a `YYYY-MM-DD` date string into `MM/DD/YYYY` format.
 
 **Example:**
 ```typescript
-import { formatYmdDate } from '@tmarois/atlas';
+import { formatYmdDate } from '@atlas/ui';
 
 formatYmdDate('2023-12-05'); // '12/05/2023'
 formatYmdDate('2023-01-01'); // '01/01/2023'
@@ -116,7 +116,7 @@ Formats a number with thousands separators and optional decimal places.
 
 **Example:**
 ```typescript
-import { formatNumber } from '@tmarois/atlas';
+import { formatNumber } from '@atlas/ui';
 
 formatNumber(1000);      // '1,000'
 formatNumber(1234.56, 2); // '1,234.56'
@@ -136,7 +136,7 @@ Formats a numeric decimal into a percentage string.
 
 **Example:**
 ```typescript
-import { formatPercentage } from '@tmarois/atlas';
+import { formatPercentage } from '@atlas/ui';
 
 formatPercentage(0.25);     // '25%'
 formatPercentage(0.3333, 2); // '33.33%'
@@ -155,7 +155,7 @@ Converts a string into a safe, lowercase slug.
 
 **Example:**
 ```typescript
-import { formatSlug } from '@tmarois/atlas';
+import { formatSlug } from '@atlas/ui';
 
 formatSlug('Hello World');      // 'hello-world'
 formatSlug('My Blog Post!');    // 'my-blog-post'
@@ -175,7 +175,7 @@ Normalizes and ensures a URL includes a valid protocol.
 
 **Example:**
 ```typescript
-import { formatValidURL } from '@tmarois/atlas';
+import { formatValidURL } from '@atlas/ui';
 
 formatValidURL('google.com');                // 'http://google.com'
 formatValidURL('google.com', true);         // 'https://google.com'
@@ -197,7 +197,7 @@ optional flag can prefix the result with `+1`.
 
 **Example:**
 ```typescript
-import { formatUSPhoneNumber } from '@tmarois/atlas';
+import { formatUSPhoneNumber } from '@atlas/ui';
 
 formatUSPhoneNumber('1234567890'); // '(123) 456-7890'
 formatUSPhoneNumber(9876543210, true); // '+1 (987) 654-3210'
@@ -219,7 +219,7 @@ Checks if a value is empty (null, undefined, empty string, empty array, or empty
 
 **Example:**
 ```typescript
-import { isEmpty } from '@tmarois/atlas';
+import { isEmpty } from '@atlas/ui';
 
 isEmpty('');        // true
 isEmpty(null);       // true
@@ -242,7 +242,7 @@ Checks if a value is a valid number or numeric string.
 
 **Example:**
 ```typescript
-import { isNumeric } from '@tmarois/atlas';
+import { isNumeric } from '@atlas/ui';
 
 isNumeric(123);        // true
 isNumeric('123');       // true
@@ -264,7 +264,7 @@ Checks if a string is a valid email address format.
 
 **Example:**
 ```typescript
-import { isValidEmail } from '@tmarois/atlas';
+import { isValidEmail } from '@atlas/ui';
 
 isValidEmail('user@example.com');      // true
 isValidEmail('name.surname@domain.co'); // true
@@ -285,7 +285,7 @@ Checks if a string is a valid URL format.
 
 **Example:**
 ```typescript
-import { isValidURL } from '@tmarois/atlas';
+import { isValidURL } from '@atlas/ui';
 
 isValidURL('https://google.com');         // true
 isValidURL('http://subdomain.domain.co.uk'); // true
@@ -307,7 +307,7 @@ Detects if the code is running in a client/browser environment (as opposed to se
 
 **Example:**
 ```typescript
-import { isClient } from '@tmarois/atlas';
+import { isClient } from '@atlas/ui';
 
 // Only execute browser-specific code when in the browser
 if (isClient) {
@@ -326,7 +326,7 @@ Returns a random element from an array.
 
 **Example:**
 ```typescript
-import { getRandomItem } from '@tmarois/atlas';
+import { getRandomItem } from '@atlas/ui';
 
 const numbers = [1, 2, 3, 4];
 getRandomItem(numbers); // 1 | 2 | 3 | 4
@@ -344,7 +344,7 @@ Rounds a number to a specified number of decimal places.
 
 **Example:**
 ```typescript
-import { roundTo } from '@tmarois/atlas';
+import { roundTo } from '@atlas/ui';
 
 roundTo(1.005, 2); // 1.01
 roundTo(123.456, 1); // 123.5
@@ -363,7 +363,7 @@ Determines whether the current Inertia page URL matches a given path.
 
 **Example:**
 ```typescript
-import { isPageActive } from '@tmarois/atlas';
+import { isPageActive } from '@atlas/ui';
 
 isPageActive('/users'); // true when current URL begins with '/users'
 isPageActive('/users', undefined, true); // true only when URL is exactly '/users'


### PR DESCRIPTION
## Summary
- document build alias setup for `@atlas/ui`
- link to app layout docs and remove redundant application section
- ensure all UI examples import from `@atlas/ui`

## Testing
- `npm test`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68ab1630176c83258baa5d470ed858a0