### PR TITLE
feat(playground): enable filtering on roles dropdown

### DIFF
--- a/playground/src/pages/components/forms/Sizing.vue
+++ b/playground/src/pages/components/forms/Sizing.vue
@@ -39,7 +39,7 @@
               />
             </LabelField>
             <LabelField name="roles" label="Roles">
-              <MultiSelect v-model="form.roles" :options="roles" optionLabel="name" optionValue="id" fluid :size="item.size" />
+              <MultiSelect v-model="form.roles" :options="roles" optionLabel="name" optionValue="id" fluid filter :size="item.size" />
             </LabelField>
             <LabelField name="autorole" label="Auto Role">
               <AutoComplete


### PR DESCRIPTION
## Summary
- allow filtering roles on forms sizing page

## Testing
- `npm test` (ui)
- `npm test` (playground, fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68ab1bc6b0a48325a4fc105acd9ad684