### PR TITLE
feat(playground): show buttons with icon and label

### DIFF
--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -13,6 +13,15 @@
             :label="state.label"
           />
         </div>
+        <div class="flex flex-wrap gap-4 mb-4">
+          <Button
+            v-for="state in states"
+            :key="`${state.label}-icon`"
+            v-bind="{ ...group.attrs, ...state.attrs }"
+            :label="state.label"
+            icon="pi pi-check"
+          />
+        </div>
         <div class="flex flex-wrap gap-4">
           <Button
             v-for="state in iconStates"


### PR DESCRIPTION
## Summary
- show buttons with text accompanied by check icons in playground examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab1d4372048325a0c9b664bb2576f1