### PR TITLE
fix: square small icon-only button

### DIFF
--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -29,8 +29,8 @@ const theme = ref<ButtonPassThroughOptions>({
         p-vertical:flex-col p-fluid:w-full p-fluid:p-icon-only:w-10
         p-icon-only:w-10 p-icon-only:px-0 p-icon-only:gap-0
         p-icon-only:p-rounded:rounded-full p-icon-only:p-rounded:h-10
-        p-small:p-icon-only:h-[34px] p-small:p-icon-only:w-[34px]
-        p-small:p-icon-only:p-rounded:h-[34px]
+        p-small:p-icon-only:p-2 p-small:p-icon-only:w-auto
+        p-small:p-icon-only:p-rounded:w-auto p-small:p-icon-only:p-rounded:h-auto
         p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
         p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
         p-raised:shadow-sm p-rounded:rounded-[2rem]

--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -26,11 +26,11 @@ const theme = ref<ButtonPassThroughOptions>({
         bg-primary-500 enabled:hover:bg-primary-500/70 enabled:active:bg-primary-500/60 text-white text-md font-semibold p-text:!font-medium
         border border-primary-500 enabled:hover:border-primary-500/70 enabled:active:border-primary-500/60
         focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
-        p-vertical:flex-col p-fluid:w-full p-fluid:p-icon-only:w-10
-        p-icon-only:w-10 p-icon-only:px-0 p-icon-only:gap-0
-        p-icon-only:p-rounded:rounded-full p-icon-only:p-rounded:h-10
-        p-small:p-icon-only:p-2 p-small:p-icon-only:w-auto
-        p-small:p-icon-only:p-rounded:w-auto p-small:p-icon-only:p-rounded:h-auto
+        p-vertical:flex-col p-fluid:w-full p-fluid:p-icon-only:w-10 p-fluid:p-icon-only:h-10
+        p-icon-only:w-10 p-icon-only:h-10 p-icon-only:p-0 p-icon-only:gap-0
+        p-icon-only:p-rounded:rounded-full
+        p-small:p-icon-only:w-[34px] p-small:p-icon-only:h-[34px] p-small:p-icon-only:p-0
+        p-large:p-icon-only:w-12 p-large:p-icon-only:h-12 p-large:p-icon-only:p-0
         p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
         p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
         p-raised:shadow-sm p-rounded:rounded-[2rem]

--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -28,9 +28,9 @@ const theme = ref<ButtonPassThroughOptions>({
         focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
         p-vertical:flex-col p-fluid:w-full p-fluid:p-icon-only:w-10
         p-icon-only:w-10 p-icon-only:px-0 p-icon-only:gap-0
-        p-small:p-icon-only:w-8
         p-icon-only:p-rounded:rounded-full p-icon-only:p-rounded:h-10
-        p-small:p-icon-only:p-rounded:h-8
+        p-small:p-icon-only:h-[34px] p-small:p-icon-only:w-[34px]
+        p-small:p-icon-only:p-rounded:h-[34px]
         p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
         p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
         p-raised:shadow-sm p-rounded:rounded-[2rem]

--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -28,7 +28,9 @@ const theme = ref<ButtonPassThroughOptions>({
         focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
         p-vertical:flex-col p-fluid:w-full p-fluid:p-icon-only:w-10
         p-icon-only:w-10 p-icon-only:px-0 p-icon-only:gap-0
+        p-small:p-icon-only:w-8
         p-icon-only:p-rounded:rounded-full p-icon-only:p-rounded:h-10
+        p-small:p-icon-only:p-rounded:h-8
         p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
         p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
         p-raised:shadow-sm p-rounded:rounded-[2rem]

--- a/ui/tests/components/Button.test.ts
+++ b/ui/tests/components/Button.test.ts
@@ -24,13 +24,27 @@ describe('Button', () => {
         expect(classes).toContain('p-small:py-[0.375rem]');
     });
 
-    it('sizes small icon-only buttons via padding without fixed dimensions', () => {
-        const wrapper = mountWithPrime({ size: 'small', icon: 'pi pi-check', rounded: true });
-        const classes = wrapper.find('button').attributes('class');
-        expect(classes).toContain('p-small:p-icon-only:p-2');
-        expect(classes).toContain('p-small:p-icon-only:w-auto');
-        expect(classes).toContain('p-small:p-icon-only:p-rounded:w-auto');
-        expect(classes).toContain('p-small:p-icon-only:p-rounded:h-auto');
+    it('ensures icon-only buttons are square across sizes', () => {
+        const cases = [
+            {
+                props: { icon: 'pi pi-check' },
+                classes: ['p-icon-only:w-10', 'p-icon-only:h-10', 'p-icon-only:p-0'],
+            },
+            {
+                props: { size: 'small', icon: 'pi pi-check' },
+                classes: ['p-small:p-icon-only:w-[34px]', 'p-small:p-icon-only:h-[34px]', 'p-icon-only:p-0'],
+            },
+            {
+                props: { size: 'large', icon: 'pi pi-check' },
+                classes: ['p-large:p-icon-only:w-12', 'p-large:p-icon-only:h-12', 'p-icon-only:p-0'],
+            },
+        ];
+
+        cases.forEach(({ props, classes: expected }) => {
+            const wrapper = mountWithPrime(props);
+            const classes = wrapper.find('button').attributes('class');
+            expected.forEach((c) => expect(classes).toContain(c));
+        });
     });
 
     it('uses 40px default height', () => {

--- a/ui/tests/components/Button.test.ts
+++ b/ui/tests/components/Button.test.ts
@@ -24,12 +24,13 @@ describe('Button', () => {
         expect(classes).toContain('p-small:py-[0.375rem]');
     });
 
-    it('uses 34px square dimensions for small icon-only', () => {
+    it('sizes small icon-only buttons via padding without fixed dimensions', () => {
         const wrapper = mountWithPrime({ size: 'small', icon: 'pi pi-check', rounded: true });
         const classes = wrapper.find('button').attributes('class');
-        expect(classes).toContain('p-small:p-icon-only:w-[34px]');
-        expect(classes).toContain('p-small:p-icon-only:h-[34px]');
-        expect(classes).toContain('p-small:p-icon-only:p-rounded:h-[34px]');
+        expect(classes).toContain('p-small:p-icon-only:p-2');
+        expect(classes).toContain('p-small:p-icon-only:w-auto');
+        expect(classes).toContain('p-small:p-icon-only:p-rounded:w-auto');
+        expect(classes).toContain('p-small:p-icon-only:p-rounded:h-auto');
     });
 
     it('uses 40px default height', () => {

--- a/ui/tests/components/Button.test.ts
+++ b/ui/tests/components/Button.test.ts
@@ -24,11 +24,12 @@ describe('Button', () => {
         expect(classes).toContain('p-small:py-[0.375rem]');
     });
 
-    it('uses square dimensions for small icon-only', () => {
+    it('uses 34px square dimensions for small icon-only', () => {
         const wrapper = mountWithPrime({ size: 'small', icon: 'pi pi-check', rounded: true });
         const classes = wrapper.find('button').attributes('class');
-        expect(classes).toContain('p-small:p-icon-only:w-8');
-        expect(classes).toContain('p-small:p-icon-only:p-rounded:h-8');
+        expect(classes).toContain('p-small:p-icon-only:w-[34px]');
+        expect(classes).toContain('p-small:p-icon-only:h-[34px]');
+        expect(classes).toContain('p-small:p-icon-only:p-rounded:h-[34px]');
     });
 
     it('uses 40px default height', () => {

--- a/ui/tests/components/Button.test.ts
+++ b/ui/tests/components/Button.test.ts
@@ -24,6 +24,13 @@ describe('Button', () => {
         expect(classes).toContain('p-small:py-[0.375rem]');
     });
 
+    it('uses square dimensions for small icon-only', () => {
+        const wrapper = mountWithPrime({ size: 'small', icon: 'pi pi-check', rounded: true });
+        const classes = wrapper.find('button').attributes('class');
+        expect(classes).toContain('p-small:p-icon-only:w-8');
+        expect(classes).toContain('p-small:p-icon-only:p-rounded:h-8');
+    });
+
     it('uses 40px default height', () => {
         const wrapper = mountWithPrime({ label: 'Test' });
         const classes = wrapper.find('button').attributes('class');


### PR DESCRIPTION
## Summary
- ensure small icon-only button uses square dimensions
- cover small icon-only size with test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab1e452e9883259e9fc53f246068d2