### PR TITLE
docs: add feedback examples

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -62,11 +62,11 @@ See the [App Layout](ui/app.md) for a ready-to-use application wrapper.
     - [Menu](#menu)
     - [Paginator](#paginator)
     - [Pagination](#pagination)
-  - [Feedback](#feedback)
-  - [Alert](#alert)
-  - [Errors](#errors)
-  - [Toast](#toast)
-  - [ProgressBar](#progressbar)
+    - [Feedback](#feedback)
+      - [Alert](#alert)
+      - [Errors](#errors)
+      - [Toast](#toast)
+      - [ProgressBar](#progressbar)
 
 ## Setup
 

--- a/playground/src/layouts/ComponentsLayout.vue
+++ b/playground/src/layouts/ComponentsLayout.vue
@@ -34,6 +34,7 @@ const pageNavItems = [
       { label: 'Tables', href: '/components/tables' },
       { label: 'Tabs', href: '/components/tabs' },
       { label: 'Overlays', href: '/components/overlays' },
+      { label: 'Feedback', href: '/components/feedback', parent: '/components/feedback' },
       { label: 'Editor', href: '/components/editor', parent: '/components/editor' },
     ],
   },
@@ -84,6 +85,13 @@ const pageTabs = computed(() => {
       { title: 'Overview', href: '/components/editor' },
       { title: 'Variants', href: '/components/editor/variant' },
       { title: 'Text', href: '/components/editor/text' },
+    ];
+  }
+  if (route.path.startsWith('/components/feedback')) {
+    return [
+      { title: 'Alerts', href: '/components/feedback' },
+      { title: 'Toast', href: '/components/feedback/toast' },
+      { title: 'ProgressBar', href: '/components/feedback/progressbar' },
     ];
   }
   return [];

--- a/playground/src/pages/components/feedback/Index.vue
+++ b/playground/src/pages/components/feedback/Index.vue
@@ -1,0 +1,17 @@
+<template>
+  <section class="space-y-4">
+    <Card>
+      <template #content>
+        <Alert class="mb-4">Default alert</Alert>
+        <Alert warning class="mb-4">Warning alert</Alert>
+        <Alert hideIcon>Alert without icon</Alert>
+      </template>
+    </Card>
+  </section>
+</template>
+
+<script setup>
+import Card from '@atlas/ui/components/Card.vue';
+import Alert from '@atlas/ui/components/Alert.vue';
+</script>
+

--- a/playground/src/pages/components/feedback/Index.vue
+++ b/playground/src/pages/components/feedback/Index.vue
@@ -4,7 +4,26 @@
       <template #content>
         <Alert class="mb-4">Default alert</Alert>
         <Alert warning class="mb-4">Warning alert</Alert>
-        <Alert hideIcon>Alert without icon</Alert>
+        <Alert hideIcon class="mb-4">Alert without icon</Alert>
+
+        <Alert class="mb-4">
+          Default alert
+          <template #actions>
+            <Button size="small" label="Add funds" />
+          </template>
+        </Alert>
+        <Alert warning class="mb-4">
+          Warning alert
+          <template #actions>
+            <Button size="small" label="Add funds" />
+          </template>
+        </Alert>
+        <Alert hideIcon>
+          Alert without icon
+          <template #actions>
+            <Button size="small" label="Add funds" />
+          </template>
+        </Alert>
       </template>
     </Card>
   </section>
@@ -13,5 +32,6 @@
 <script setup>
 import Card from '@atlas/ui/components/Card.vue';
 import Alert from '@atlas/ui/components/Alert.vue';
+import Button from '@atlas/ui/components/Button.vue';
 </script>
 

--- a/playground/src/pages/components/feedback/ProgressBar.vue
+++ b/playground/src/pages/components/feedback/ProgressBar.vue
@@ -1,0 +1,15 @@
+<template>
+  <section class="space-y-4">
+    <Card>
+      <template #content>
+        <ProgressBar :value="50" />
+      </template>
+    </Card>
+  </section>
+</template>
+
+<script setup>
+import Card from '@atlas/ui/components/Card.vue';
+import ProgressBar from '@atlas/ui/components/ProgressBar.vue';
+</script>
+

--- a/playground/src/pages/components/feedback/Toast.vue
+++ b/playground/src/pages/components/feedback/Toast.vue
@@ -1,0 +1,23 @@
+<template>
+  <section class="space-y-4">
+    <Card>
+      <template #content>
+        <Button label="Show Toast" @click="show" />
+        <Toast />
+      </template>
+    </Card>
+  </section>
+</template>
+
+<script setup>
+import Card from '@atlas/ui/components/Card.vue';
+import Button from '@atlas/ui/components/Button.vue';
+import Toast from '@atlas/ui/components/Toast.vue';
+import { useToast } from 'primevue/usetoast';
+
+const toast = useToast();
+const show = () => {
+  toast.add({ severity: 'info', summary: 'Info', detail: 'Message Content', life: 3000 });
+};
+</script>
+

--- a/playground/src/pages/components/feedback/Toast.vue
+++ b/playground/src/pages/components/feedback/Toast.vue
@@ -3,7 +3,6 @@
     <Card>
       <template #content>
         <Button label="Show Toast" @click="show" />
-        <Toast />
       </template>
     </Card>
   </section>
@@ -12,7 +11,6 @@
 <script setup>
 import Card from '@atlas/ui/components/Card.vue';
 import Button from '@atlas/ui/components/Button.vue';
-import Toast from '@atlas/ui/components/Toast.vue';
 import { useToast } from 'primevue/usetoast';
 
 const toast = useToast();

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -8,6 +8,9 @@ import FormsErrors from './pages/components/forms/Errors.vue';
 import Tables from './pages/components/Tables.vue';
 import Tabs from './pages/components/Tabs.vue';
 import Overlays from './pages/components/Overlays.vue';
+import Feedback from './pages/components/feedback/Index.vue';
+import FeedbackToast from './pages/components/feedback/Toast.vue';
+import FeedbackProgressBar from './pages/components/feedback/ProgressBar.vue';
 import Editor from './pages/components/editor/Index.vue';
 import EditorVariant from './pages/components/editor/Variant.vue';
 import EditorText from './pages/components/editor/Text.vue';
@@ -52,6 +55,9 @@ const routes = [
       { path: 'tables', component: Tables, meta: { title: 'Tables' } },
       { path: 'tabs', component: Tabs, meta: { title: 'Tabs' } },
       { path: 'overlays', component: Overlays, meta: { title: 'Overlays' } },
+      { path: 'feedback', component: Feedback, meta: { title: 'Feedback' } },
+      { path: 'feedback/toast', component: FeedbackToast, meta: { title: 'Feedback' } },
+      { path: 'feedback/progressbar', component: FeedbackProgressBar, meta: { title: 'Feedback' } },
       { path: 'editor', component: Editor, meta: { title: 'Editor' } },
       { path: 'editor/variant', component: EditorVariant, meta: { title: 'Editor Variants' } },
       { path: 'editor/text', component: EditorText, meta: { title: 'Editor Text' } },


### PR DESCRIPTION
## Summary
- align Feedback items under the Components documentation TOC
- add playground Feedback pages with examples for Alerts, Toast, and ProgressBar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab1f1cb20c8325bc93111e0ca1a5e7