### PR TITLE
feat(playground): add errors feedback page

### DIFF
--- a/playground/src/layouts/ComponentsLayout.vue
+++ b/playground/src/layouts/ComponentsLayout.vue
@@ -90,6 +90,7 @@ const pageTabs = computed(() => {
   if (route.path.startsWith('/components/feedback')) {
     return [
       { title: 'Alerts', href: '/components/feedback' },
+      { title: 'Errors', href: '/components/feedback/errors' },
       { title: 'Toast', href: '/components/feedback/toast' },
       { title: 'ProgressBar', href: '/components/feedback/progressbar' },
     ];

--- a/playground/src/pages/components/feedback/Errors.vue
+++ b/playground/src/pages/components/feedback/Errors.vue
@@ -1,0 +1,34 @@
+<template>
+  <section class="space-y-4">
+    <Card>
+      <template #content>
+        <Errors :errors="['Email is required', 'Password must be at least 8 characters']" />
+      </template>
+    </Card>
+
+    <Card>
+      <template #content>
+        <Errors
+          :errors="{ name: 'Name is required', email: 'Email is invalid' }"
+          title="Please fix the following:"
+        />
+      </template>
+    </Card>
+
+    <Card>
+      <template #content>
+        <Errors :failed="true" :expandDefault="false">
+          <template #defaultError>
+            <span>Something went wrong. Try again later.</span>
+          </template>
+        </Errors>
+      </template>
+    </Card>
+  </section>
+</template>
+
+<script setup>
+import Card from '@atlas/ui/components/Card.vue';
+import Errors from '@atlas/ui/components/Errors.vue';
+</script>
+

--- a/playground/src/router.js
+++ b/playground/src/router.js
@@ -9,6 +9,7 @@ import Tables from './pages/components/Tables.vue';
 import Tabs from './pages/components/Tabs.vue';
 import Overlays from './pages/components/Overlays.vue';
 import Feedback from './pages/components/feedback/Index.vue';
+import FeedbackErrors from './pages/components/feedback/Errors.vue';
 import FeedbackToast from './pages/components/feedback/Toast.vue';
 import FeedbackProgressBar from './pages/components/feedback/ProgressBar.vue';
 import Editor from './pages/components/editor/Index.vue';
@@ -56,6 +57,7 @@ const routes = [
       { path: 'tabs', component: Tabs, meta: { title: 'Tabs' } },
       { path: 'overlays', component: Overlays, meta: { title: 'Overlays' } },
       { path: 'feedback', component: Feedback, meta: { title: 'Feedback' } },
+      { path: 'feedback/errors', component: FeedbackErrors, meta: { title: 'Feedback' } },
       { path: 'feedback/toast', component: FeedbackToast, meta: { title: 'Feedback' } },
       { path: 'feedback/progressbar', component: FeedbackProgressBar, meta: { title: 'Feedback' } },
       { path: 'editor', component: Editor, meta: { title: 'Editor' } },


### PR DESCRIPTION
## Summary
- add Errors component demo page in feedback playground
- wire up router and navigation tabs for new page

## Testing
- `npm test` (ui)
- `composer test` (laravel) *(fails: vendor/bin/phpunit not found)*
- `npm test` (playground) *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_b_68ab354070b08325bef6abb6cb0586e5