### PR TITLE
Add DatePicker examples to form edit cards

### DIFF
--- a/playground/src/pages/components/forms/Errors.vue
+++ b/playground/src/pages/components/forms/Errors.vue
@@ -37,6 +37,17 @@
                 <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear forceSelection :invalid="true" />
               </LabelField>
             </div>
+            <div class="w-full flex items-center space-x-4">
+              <LabelField name="date" label="Date" :error="errors.date">
+                <DatePicker id="date" v-model="form.date" fluid :invalid="true" />
+              </LabelField>
+              <LabelField name="month" label="Month" :error="errors.month">
+                <DatePicker id="month" v-model="form.month" view="month" dateFormat="mm/yy" fluid :invalid="true" />
+              </LabelField>
+              <LabelField name="time" label="Time" :error="errors.time">
+                <DatePicker id="time" v-model="form.time" timeOnly fluid :invalid="true" />
+              </LabelField>
+            </div>
           </div>
         </template>
         <template #footer>
@@ -62,6 +73,7 @@ import InputText from '@atlas/ui/components/InputText.vue';
 import Select from '@atlas/ui/components/Select.vue';
 import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
 import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
+import DatePicker from '@atlas/ui/components/DatePicker.vue';
 import { useModal } from '@atlas/ui/composables';
 import Errors from '@atlas/ui/components/Errors.vue';
 
@@ -73,6 +85,9 @@ const form = reactive({
   roles: [],
   gender: null,
   autorole: null,
+  date: null,
+  month: null,
+  time: null,
 });
 
 const errors = reactive({
@@ -81,6 +96,9 @@ const errors = reactive({
   gender: 'Gender is required',
   roles: 'Roles are required',
   autorole: 'Role is required',
+  date: 'Date is required',
+  month: 'Month is required',
+  time: 'Time is required',
 });
 
 const roles = ref([

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -50,6 +50,17 @@
                   <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid dropdown showClear forceSelection />
                 </LabelField>
               </div>
+              <div class="w-full flex items-center space-x-4">
+                <LabelField name="date" label="Date">
+                  <DatePicker id="date" v-model="form.date" fluid />
+                </LabelField>
+                <LabelField name="month" label="Month">
+                  <DatePicker id="month" v-model="form.month" view="month" dateFormat="mm/yy" fluid />
+                </LabelField>
+                <LabelField name="time" label="Time">
+                  <DatePicker id="time" v-model="form.time" timeOnly fluid />
+                </LabelField>
+              </div>
             </div>
           </template>
         </Card>
@@ -93,6 +104,17 @@
               <div class="w-full">
                 <LabelField name="roles" label="Roles (autocomplete)">
                   <AutoComplete v-model="form.autorole" :suggestions="filteredRoles" @complete="search" optionLabel="label" optionValue="id" fluid :disabled="true" dropdown showClear forceSelection />
+                </LabelField>
+              </div>
+              <div class="w-full flex items-center space-x-4">
+                <LabelField name="date" label="Date">
+                  <DatePicker id="date" v-model="form.date" fluid :disabled="true" />
+                </LabelField>
+                <LabelField name="month" label="Month">
+                  <DatePicker id="month" v-model="form.month" view="month" dateFormat="mm/yy" fluid :disabled="true" />
+                </LabelField>
+                <LabelField name="time" label="Time">
+                  <DatePicker id="time" v-model="form.time" timeOnly fluid :disabled="true" />
                 </LabelField>
               </div>
             </div>
@@ -207,6 +229,7 @@ import InputText from '@atlas/ui/components/InputText.vue';
 import Select from '@atlas/ui/components/Select.vue';
 import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
 import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
+import DatePicker from '@atlas/ui/components/DatePicker.vue';
 import InputNumber from '@atlas/ui/components/InputNumber.vue';
 import Alert from '@atlas/ui/components/Alert.vue';
 import LabelCheckbox from '@atlas/ui/components/LabelCheckbox.vue';
@@ -228,6 +251,9 @@ const form = reactive({
     checked: 'on',
     gender: null,
     autorole: null,
+    date: null,
+    month: null,
+    time: null,
 });
 
 const roles = ref([

--- a/playground/src/pages/components/forms/Sizing.vue
+++ b/playground/src/pages/components/forms/Sizing.vue
@@ -58,6 +58,17 @@
               <Select v-model="form.gender" :options="genders" optionLabel="gender" optionValue="id" fluid :size="item.size" />
             </LabelField>
           </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <LabelField name="date" label="Date">
+              <DatePicker v-model="form.date" fluid :size="item.size" />
+            </LabelField>
+            <LabelField name="month" label="Month">
+              <DatePicker v-model="form.month" view="month" dateFormat="mm/yy" fluid :size="item.size" />
+            </LabelField>
+            <LabelField name="time" label="Time">
+              <DatePicker v-model="form.time" timeOnly fluid :size="item.size" />
+            </LabelField>
+          </div>
         </div>
       </template>
       <template #footer>
@@ -78,6 +89,7 @@ import InputText from '@atlas/ui/components/InputText.vue';
 import Select from '@atlas/ui/components/Select.vue';
 import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
 import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
+import DatePicker from '@atlas/ui/components/DatePicker.vue';
 import InputNumber from '@atlas/ui/components/InputNumber.vue';
 import Button from '@atlas/ui/components/Button.vue';
 
@@ -93,6 +105,9 @@ const form = reactive({
   checked: 'on',
   gender: null,
   autorole: null,
+  date: null,
+  month: null,
+  time: null,
   query: null,
 });
 


### PR DESCRIPTION
## Summary
- showcase DatePicker usage for date, month, and time in edit form examples
- add disabled DatePicker examples mirroring active fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab37ae8a7083258d2b78244e14f4a1