### PR TITLE
fix: merge dialog confirmation styles

### DIFF
--- a/ui/src/components/DialogConfirmation.vue
+++ b/ui/src/components/DialogConfirmation.vue
@@ -97,11 +97,23 @@ const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
 const dialogBindProps = computed(() => {
     const { style, ...rest } = bindProps.value as any;
 
+    const parsedStyle =
+        typeof style === 'string'
+            ? style
+                  .split(';')
+                  .filter(Boolean)
+                  .reduce((acc: Record<string, string>, item) => {
+                      const [prop, val] = item.split(':');
+                      if (prop && val) acc[prop.trim()] = val.trim();
+                      return acc;
+                  }, {})
+            : style;
+
     return {
         modal: true,
         dismissableMask: false,
         closable: false,
-        style: { width: '25rem', ...style },
+        style: { width: '25rem', ...parsedStyle },
         ...rest,
         header: props.title,
         visible: props.modelValue,

--- a/ui/src/components/DialogConfirmation.vue
+++ b/ui/src/components/DialogConfirmation.vue
@@ -94,15 +94,19 @@ const passThroughProps = computed(() => {
 
 const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
 
-const dialogBindProps = computed(() => ({
-    modal: true,
-    dismissableMask: false,
-    closable: false,
-    style: { width: '25rem' },
-    ...bindProps.value,
-    header: props.title,
-    visible: props.modelValue,
-}));
+const dialogBindProps = computed(() => {
+    const { style, ...rest } = bindProps.value as any;
+
+    return {
+        modal: true,
+        dismissableMask: false,
+        closable: false,
+        style: { width: '25rem', ...style },
+        ...rest,
+        header: props.title,
+        visible: props.modelValue,
+    };
+});
 
 const close = () => emit('update:modelValue', false);
 const confirm = () => emit('confirm');

--- a/ui/tests/components/DialogConfirmation.test.ts
+++ b/ui/tests/components/DialogConfirmation.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+import DialogConfirmation from '../../src/components/DialogConfirmation.vue';
+
+const mountWithPrime = (props: any = {}, slots: any = {}) =>
+    mount(DialogConfirmation, {
+        global: { plugins: [PrimeVue] },
+        props,
+        slots,
+    });
+
+describe('DialogConfirmation', () => {
+    it('merges provided style with default style', () => {
+        const wrapper = mountWithPrime({ modelValue: true, style: { height: '100px' } });
+        expect(wrapper.vm.dialogBindProps.style).toMatchObject({ width: '25rem', height: '100px' });
+    });
+});

--- a/ui/tests/components/DialogConfirmation.test.ts
+++ b/ui/tests/components/DialogConfirmation.test.ts
@@ -15,4 +15,9 @@ describe('DialogConfirmation', () => {
         const wrapper = mountWithPrime({ modelValue: true, style: { height: '100px' } });
         expect(wrapper.vm.dialogBindProps.style).toMatchObject({ width: '25rem', height: '100px' });
     });
+
+    it('merges style string with default style', () => {
+        const wrapper = mountWithPrime({ modelValue: true, style: 'height: 100px;' });
+        expect(wrapper.vm.dialogBindProps.style).toMatchObject({ width: '25rem', height: '100px' });
+    });
 });


### PR DESCRIPTION
## Summary
- merge `style` prop with defaults in dialog confirmation
- add unit test to ensure styles are preserved when passing custom styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab390ce5b48325b527f4f4b2d455f4