### PR TITLE
Add indeterminate progress bar playground example

### DIFF
--- a/playground/src/pages/components/feedback/ProgressBar.vue
+++ b/playground/src/pages/components/feedback/ProgressBar.vue
@@ -28,6 +28,12 @@
         <ProgressBar :value="animatedValue" />
       </template>
     </Card>
+
+    <Card>
+      <template #content>
+        <ProgressBar mode="indeterminate" />
+      </template>
+    </Card>
   </section>
 </template>
 


### PR DESCRIPTION
## Summary
- showcase an indeterminate progress bar variant in the playground

## Testing
- `cd playground && npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68ab3f18c4b48325aa22cdc58a650a61