### PR TITLE
Add textarea examples to forms playground

### DIFF
--- a/playground/src/pages/components/forms/Errors.vue
+++ b/playground/src/pages/components/forms/Errors.vue
@@ -48,6 +48,11 @@
                 <DatePicker id="time" v-model="form.time" timeOnly fluid :invalid="true" />
               </LabelField>
             </div>
+            <div class="w-full">
+              <LabelField name="description" label="Description" :error="errors.description">
+                <Textarea id="description_invalid" v-model="form.description" fluid autoResize :invalid="true" />
+              </LabelField>
+            </div>
           </div>
         </template>
         <template #footer>
@@ -74,6 +79,7 @@ import Select from '@atlas/ui/components/Select.vue';
 import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
 import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
 import DatePicker from '@atlas/ui/components/DatePicker.vue';
+import Textarea from '@atlas/ui/components/Textarea.vue';
 import { useModal } from '@atlas/ui/composables';
 import Errors from '@atlas/ui/components/Errors.vue';
 
@@ -88,6 +94,7 @@ const form = reactive({
   date: null,
   month: null,
   time: null,
+  description: null,
 });
 
 const errors = reactive({
@@ -99,6 +106,7 @@ const errors = reactive({
   date: 'Date is required',
   month: 'Month is required',
   time: 'Time is required',
+  description: 'Description is required',
 });
 
 const roles = ref([

--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -61,6 +61,11 @@
                   <DatePicker id="time" v-model="form.time" timeOnly fluid />
                 </LabelField>
               </div>
+              <div class="w-full">
+                <LabelField name="description" label="Description">
+                  <Textarea id="description" v-model="form.description" fluid autoResize />
+                </LabelField>
+              </div>
             </div>
           </template>
         </Card>
@@ -115,6 +120,11 @@
                 </LabelField>
                 <LabelField name="time" label="Time">
                   <DatePicker id="time" v-model="form.time" timeOnly fluid :disabled="true" />
+                </LabelField>
+              </div>
+              <div class="w-full">
+                <LabelField name="description" label="Description">
+                  <Textarea id="description_disabled" v-model="form.description" fluid :disabled="true" autoResize />
                 </LabelField>
               </div>
             </div>
@@ -230,6 +240,7 @@ import Select from '@atlas/ui/components/Select.vue';
 import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
 import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
 import DatePicker from '@atlas/ui/components/DatePicker.vue';
+import Textarea from '@atlas/ui/components/Textarea.vue';
 import InputNumber from '@atlas/ui/components/InputNumber.vue';
 import Alert from '@atlas/ui/components/Alert.vue';
 import LabelCheckbox from '@atlas/ui/components/LabelCheckbox.vue';
@@ -254,6 +265,7 @@ const form = reactive({
     date: null,
     month: null,
     time: null,
+    description: null,
 });
 
 const roles = ref([


### PR DESCRIPTION
## Summary
- showcase `Textarea` usage in forms playground with normal and disabled states
- demonstrate textarea validation in form error examples

## Testing
- `npm test` (playground) *(fails: Missing script "test")*
- `npm test` (ui)


------
https://chatgpt.com/codex/tasks/task_b_68ab3ea1ae708325a161d9233f3cbc3c