### PR TITLE
chore(playground): add default form values

### DIFF
--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -252,20 +252,20 @@ const { open } = useModal();
 
 const form = reactive({
     first_name: 'John',
-    last_name: null,
-    amount: null,
+    last_name: 'Doe',
+    amount: 100,
     email: 'example@example.com',
-    roles: [],
+    roles: ['admin', 'user'],
     type: 'credit',
-    payment: 'disabled',
-    agree: false,
+    payment: 'Now',
+    agree: true,
     checked: 'on',
-    gender: null,
-    autorole: null,
-    date: null,
-    month: null,
-    time: null,
-    description: null,
+    gender: 'male',
+    autorole: 'admin',
+    date: new Date('2024-01-01'),
+    month: new Date('2024-02-01'),
+    time: new Date('2024-01-01T12:00:00'),
+    description: 'Example description',
 });
 
 const roles = ref([


### PR DESCRIPTION
## Summary
- prefill playground forms so edit and disabled cards show sample values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab4050608883258917ca17455c2bf3