### PR TITLE
feat(playground): add button group examples

### DIFF
--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -33,11 +33,29 @@
         </div>
       </template>
     </Card>
+    <Card>
+      <template #header>
+        <h3 class="text-lg font-semibold">Button Groups</h3>
+      </template>
+      <template #content>
+        <div class="flex flex-wrap gap-4">
+          <ButtonGroup v-for="size in buttonGroupSizes" :key="size.key">
+            <Button
+              v-for="state in states"
+              :key="`${size.key}-${state.label}`"
+              v-bind="{ ...size.attrs, ...state.attrs }"
+              :label="state.label"
+            />
+          </ButtonGroup>
+        </div>
+      </template>
+    </Card>
   </section>
 </template>
 
 <script setup>
 import Button from '@atlas/ui/components/Button.vue';
+import ButtonGroup from '@atlas/ui/components/ButtonGroup.vue';
 import Card from '@atlas/ui/components/Card.vue';
 
 const groups = [
@@ -66,5 +84,11 @@ const iconStates = [
   { icon: 'pi pi-times', attrs: { rounded: true }, ariaLabel: 'Close' },
   { icon: 'pi pi-refresh', attrs: { loading: true }, ariaLabel: 'Refresh' },
   { icon: 'pi pi-trash', attrs: { disabled: true }, ariaLabel: 'Delete' },
+];
+
+const buttonGroupSizes = [
+  { key: 'regular', attrs: {} },
+  { key: 'small', attrs: { size: 'small' } },
+  { key: 'large', attrs: { size: 'large' } },
 ];
 </script>

--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -39,11 +39,11 @@
       </template>
       <template #content>
         <div class="flex flex-wrap gap-4">
-          <ButtonGroup v-for="size in buttonGroupSizes" :key="size.key">
+          <ButtonGroup v-for="config in buttonGroupConfigs" :key="config.key">
             <Button
               v-for="state in states"
-              :key="`${size.key}-${state.label}`"
-              v-bind="{ ...size.attrs, ...state.attrs }"
+              :key="`${config.key}-${state.label}`"
+              v-bind="{ ...config.attrs, ...state.attrs }"
               :label="state.label"
             />
           </ButtonGroup>
@@ -73,7 +73,6 @@ const groups = [
 const states = [
   { label: 'Default', attrs: {} },
   { label: 'Raised', attrs: { raised: true } },
-  { label: 'Rounded', attrs: { rounded: true } },
   { label: 'Loading', attrs: { loading: true } },
   { label: 'Disabled', attrs: { disabled: true } },
 ];
@@ -81,14 +80,16 @@ const states = [
 const iconStates = [
   { icon: 'pi pi-check', attrs: {}, ariaLabel: 'Check' },
   { icon: 'pi pi-search', attrs: { raised: true }, ariaLabel: 'Search' },
-  { icon: 'pi pi-times', attrs: { rounded: true }, ariaLabel: 'Close' },
   { icon: 'pi pi-refresh', attrs: { loading: true }, ariaLabel: 'Refresh' },
   { icon: 'pi pi-trash', attrs: { disabled: true }, ariaLabel: 'Delete' },
 ];
 
-const buttonGroupSizes = [
+const buttonGroupConfigs = [
   { key: 'regular', attrs: {} },
+  { key: 'regular-outlined', attrs: { outlined: true } },
   { key: 'small', attrs: { size: 'small' } },
+  { key: 'small-outlined', attrs: { size: 'small', outlined: true } },
   { key: 'large', attrs: { size: 'large' } },
+  { key: 'large-outlined', attrs: { size: 'large', outlined: true } },
 ];
 </script>

--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -38,15 +38,32 @@
         <h3 class="text-lg font-semibold">Button Groups</h3>
       </template>
       <template #content>
-        <div class="flex flex-wrap gap-4">
-          <ButtonGroup v-for="config in buttonGroupConfigs" :key="config.key">
-            <Button
-              v-for="state in states"
-              :key="`${config.key}-${state.label}`"
-              v-bind="{ ...config.attrs, ...state.attrs }"
-              :label="state.label"
-            />
-          </ButtonGroup>
+        <div class="space-y-6">
+          <div
+            v-for="size in buttonGroupSizes"
+            :key="size.key"
+            class="space-y-2"
+          >
+            <h4 class="text-base font-medium capitalize">{{ size.label }}</h4>
+            <div class="grid grid-cols-2 gap-4">
+              <ButtonGroup>
+                <Button
+                  v-for="state in states"
+                  :key="`solid-${size.key}-${state.label}`"
+                  v-bind="{ ...size.attrs, ...state.attrs }"
+                  :label="state.label"
+                />
+              </ButtonGroup>
+              <ButtonGroup>
+                <Button
+                  v-for="state in states"
+                  :key="`outlined-${size.key}-${state.label}`"
+                  v-bind="{ ...size.attrs, outlined: true, ...state.attrs }"
+                  :label="state.label"
+                />
+              </ButtonGroup>
+            </div>
+          </div>
         </div>
       </template>
     </Card>
@@ -72,24 +89,21 @@ const groups = [
 
 const states = [
   { label: 'Default', attrs: {} },
-  { label: 'Raised', attrs: { raised: true } },
+  { label: 'Search', attrs: { icon: 'pi pi-search' } },
   { label: 'Loading', attrs: { loading: true } },
   { label: 'Disabled', attrs: { disabled: true } },
 ];
 
 const iconStates = [
   { icon: 'pi pi-check', attrs: {}, ariaLabel: 'Check' },
-  { icon: 'pi pi-search', attrs: { raised: true }, ariaLabel: 'Search' },
+  { icon: 'pi pi-search', attrs: {}, ariaLabel: 'Search' },
   { icon: 'pi pi-refresh', attrs: { loading: true }, ariaLabel: 'Refresh' },
   { icon: 'pi pi-trash', attrs: { disabled: true }, ariaLabel: 'Delete' },
 ];
 
-const buttonGroupConfigs = [
-  { key: 'regular', attrs: {} },
-  { key: 'regular-outlined', attrs: { outlined: true } },
-  { key: 'small', attrs: { size: 'small' } },
-  { key: 'small-outlined', attrs: { size: 'small', outlined: true } },
-  { key: 'large', attrs: { size: 'large' } },
-  { key: 'large-outlined', attrs: { size: 'large', outlined: true } },
+const buttonGroupSizes = [
+  { key: 'regular', label: 'Normal', attrs: {} },
+  { key: 'small', label: 'Small', attrs: { size: 'small' } },
+  { key: 'large', label: 'Large', attrs: { size: 'large' } },
 ];
 </script>


### PR DESCRIPTION
## Summary
- showcase button groups across sizes with various states on Buttons playground page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab44333ed883259eb108f70bea81da