### PR TITLE
docs: clarify navigation components

### DIFF
--- a/docs/ui/application.md
+++ b/docs/ui/application.md
@@ -4,19 +4,23 @@ Composes navigation, page chrome, and page content into a full application wrapp
 
 ## Table of Contents
 
-### Navigation
-- [NavTopbar](application/nav-topbar.md)
-- [NavSidebar](application/nav-sidebar.md)
-- [PageSideNav](application/page-side-nav.md)
+- App Navigation
+  - [NavTopbar](application/nav-topbar.md)
+  - [NavSidebar](application/nav-sidebar.md)
+- App Layout
+  - [App](#app)
+  - [AppTopbar](application/app-topbar.md)
+- Page Navigation
+  - [PageSideNav](application/page-side-nav.md)
+- Page Layout
+  - [PageHeader](application/page-header.md)
+  - [PageSideContent](application/page-side-content.md)
+  - [PageContent](application/page-content.md)
+  - [PageFooter](application/page-footer.md)
 
-### Layout
-- [AppTopbar](application/app-topbar.md)
-- [PageHeader](application/page-header.md)
-- [PageContent](application/page-content.md)
-- [PageFooter](application/page-footer.md)
-- [PageSideContent](application/page-side-content.md)
+## App
 
-## Example
+### Example
 ```ts
 import { App as LayoutApp } from '@atlas/ui';
 ```
@@ -65,7 +69,7 @@ import { App as LayoutApp } from '@atlas/ui';
 </LayoutApp>
 ```
 
-## Props
+### Props
 - `pageUrl: string` – current page identifier.
 - `isSideNav: boolean` – render side navigation when true; top bar when false. Default `true`.
 - `hasToast: boolean` – include global `<Toast>` instance. Default `true`.
@@ -80,7 +84,7 @@ import { App as LayoutApp } from '@atlas/ui';
 - `containerClass: string` – additional classes for the main container. Default `'mx-auto p-4'`.
 - `noScroll: boolean` – disable vertical scrolling for the main content. Default `false`.
 
-## Slots
+### Slots
 - `nav` – replace the navigation area entirely.
 - `navLogo` – logo inside default navigation components.
 - `navActions` – action area in navigation.
@@ -93,5 +97,5 @@ import { App as LayoutApp } from '@atlas/ui';
 - `modals` – render modal components outside the layout.
 - `default` – main page content.
 
-## Events
+### Events
 - None

--- a/docs/ui/application/nav-sidebar.md
+++ b/docs/ui/application/nav-sidebar.md
@@ -5,10 +5,23 @@ Vertical navigation sidebar.
 ## Example
 ```ts
 import { NavSidebar } from '@atlas/ui';
+const navItems = [
+  {
+    children: [
+      { label: 'Home', href: '/' },
+      { label: 'Users', href: '/users' }
+    ]
+  },
+  {
+    children: [
+      { label: 'Settings', href: '/settings' }
+    ]
+  }
+];
 ```
 
 ```vue
-<NavSidebar :items="navItems" :linkComponent="Link" homeUrl="/">
+<NavSidebar :items="navItems" :linkComponent="Link" logoLinkPath="/">
   <template #logo>
     <img src="/logo.svg" alt="Logo" />
   </template>
@@ -20,7 +33,7 @@ import { NavSidebar } from '@atlas/ui';
 
 ## Props
 - `items: NavItem[]` – sections and links displayed in the sidebar.
-- `homeUrl: string` – root link. Default `'/'`.
+- `logoLinkPath: string` – root link. Default `'/'`.
 - `linkComponent: string | object` – component used for links. Default `'a'`.
 
 ## Slots

--- a/docs/ui/application/nav-topbar.md
+++ b/docs/ui/application/nav-topbar.md
@@ -5,10 +5,21 @@ Global top navigation bar.
 ## Example
 ```ts
 import { NavTopbar } from '@atlas/ui';
+const navItems = [
+  { label: 'Dashboard', href: '/' },
+  {
+    label: 'Users',
+    href: '/users',
+    children: [
+      { label: 'List', href: '/users' },
+      { label: 'Create', href: '/users/create' }
+    ]
+  }
+];
 ```
 
 ```vue
-<NavTopbar :items="navItems" :linkComponent="Link" homeUrl="/">
+<NavTopbar :items="navItems" :linkComponent="Link" logoLinkPath="/">
   <template #logo>
     <img src="/logo.svg" alt="Logo" />
   </template>
@@ -21,7 +32,7 @@ import { NavTopbar } from '@atlas/ui';
 ## Props
 - `items: NavItem[]` – navigation links, supports nested `children`.
 - `linkComponent: string | object` – component used for links. Default `'a'`.
-- `homeUrl: string` – root link. Default `'/'`.
+- `logoLinkPath: string` – root link. Default `'/'`.
 - `widthClass: string` – max width container class. Default `'max-w-screen-2xl'`.
 
 ## Slots

--- a/docs/ui/application/page-side-nav.md
+++ b/docs/ui/application/page-side-nav.md
@@ -5,6 +5,16 @@ Secondary navigation within a page.
 ## Example
 ```ts
 import { PageSideNav } from '@atlas/ui';
+const sideItems = [
+  {
+    label: 'Group',
+    children: [
+      { label: 'Overview', href: '/overview' },
+      { label: 'Reports', href: '/reports' }
+    ]
+  },
+  { label: 'Settings', href: '/settings' }
+];
 ```
 
 ```vue

--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="relative dark flex flex-col items-center w-16 h-full overflow-hidden text-white/80 bg-surface-800 border-r border-surface-700 z-[99]">
-        <component :is="linkComponent" class="flex items-center justify-center h-14" :href="homeUrl">
+        <component :is="linkComponent" class="flex items-center justify-center h-14" :href="logoLinkPath">
             <div class="flex-shrink-0">
                 <slot name="logo">
                     <svg
@@ -67,7 +67,7 @@ const props = defineProps({
         type: Array,
         required: true
     },
-    homeUrl: {
+    logoLinkPath: {
         type: String,
         default: '/'
     },

--- a/ui/src/components/App/Nav/Topbar.vue
+++ b/ui/src/components/App/Nav/Topbar.vue
@@ -4,7 +4,7 @@
             <div class="flex h-16 items-center justify-between">
                 <div class="flex items-center">
                     <div class="flex-shrink-0">
-                        <component :is="linkComponent" :href="homeUrl" class="inline-flex items-center h-8">
+                        <component :is="linkComponent" :href="logoLinkPath" class="inline-flex items-center h-8">
                             <slot name="logo">
                                 <svg
                                     xmlns="http://www.w3.org/2000/svg"
@@ -88,7 +88,7 @@ const props = defineProps({
         type: [String, Object],
         default: 'a',
     },
-    homeUrl: {
+    logoLinkPath: {
         type: String,
         default: '/',
     },


### PR DESCRIPTION
## Summary
- rename navigation logo link prop to `logoLinkPath`
- document NavSidebar, NavTopbar, and PageSideNav item examples
- reorganize application layout table of contents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab47bb9b448325894be036b43d39c9