### PR TITLE
fix(ui): align icon buttons in groups

### DIFF
--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -21,7 +21,7 @@ const props = defineProps<Props>();
 const attrs = useAttrs();
 
 const theme = ref<ButtonPassThroughOptions>({
-    root: `inline-flex self-start cursor-pointer select-none items-center justify-center overflow-hidden relative
+    root: `inline-flex cursor-pointer select-none items-center justify-center overflow-hidden relative
         px-4 py-[9px] leading-5 gap-2 rounded disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
         bg-primary-500 enabled:hover:bg-primary-500/70 enabled:active:bg-primary-500/60 text-white text-md font-semibold p-text:!font-medium
         border border-primary-500 enabled:hover:border-primary-500/70 enabled:active:border-primary-500/60

--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -21,7 +21,7 @@ const props = defineProps<Props>();
 const attrs = useAttrs();
 
 const theme = ref<ButtonPassThroughOptions>({
-    root: `inline-flex cursor-pointer select-none items-center justify-center overflow-hidden relative
+    root: `inline-flex align-middle cursor-pointer select-none items-center justify-center overflow-hidden relative
         px-4 py-[9px] leading-5 gap-2 rounded disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
         bg-primary-500 enabled:hover:bg-primary-500/70 enabled:active:bg-primary-500/60 text-white text-md font-semibold p-text:!font-medium
         border border-primary-500 enabled:hover:border-primary-500/70 enabled:active:border-primary-500/60

--- a/ui/tests/components/Button.test.ts
+++ b/ui/tests/components/Button.test.ts
@@ -24,6 +24,12 @@ describe('Button', () => {
         expect(classes).toContain('p-small:py-[0.375rem]');
     });
 
+    it('does not offset icon buttons in groups', () => {
+        const wrapper = mountWithPrime({ icon: 'pi pi-check', label: 'Icon' });
+        const classes = wrapper.find('button').attributes('class');
+        expect(classes).not.toContain('self-start');
+    });
+
     it('ensures icon-only buttons are square across sizes', () => {
         const cases = [
             {

--- a/ui/tests/components/Button.test.ts
+++ b/ui/tests/components/Button.test.ts
@@ -24,9 +24,10 @@ describe('Button', () => {
         expect(classes).toContain('p-small:py-[0.375rem]');
     });
 
-    it('does not offset icon buttons in groups', () => {
+    it('aligns icon buttons consistently in groups', () => {
         const wrapper = mountWithPrime({ icon: 'pi pi-check', label: 'Icon' });
         const classes = wrapper.find('button').attributes('class');
+        expect(classes).toContain('align-middle');
         expect(classes).not.toContain('self-start');
     });
 


### PR DESCRIPTION
## Summary
- remove `self-start` from button root class to prevent vertical shift in button groups with icons
- add regression test ensuring icon buttons are not offset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab49a287588325a5209cada61ec325