### PR TITLE
feat(playground): add theme settings drawer

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,7 +1,9 @@
 <template>
   <RouterView />
+  <ConfigDrawer />
 </template>
 
 <script setup>
 import { RouterView } from 'vue-router';
+import ConfigDrawer from './components/ConfigDrawer.vue';
 </script>

--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <button
+      class="fixed z-50 top-1/2 -right-4 transform -translate-y-1/2 bg-primary-500 text-white p-3 rounded-l shadow flex items-center justify-center"
+      @click="visible = true"
+    >
+      <span class="pi pi-cog"></span>
+    </button>
+    <UiDrawer v-model:visible="visible" position="right" :modal="false">
+      <div class="p-4 space-y-4">
+        <h2 class="text-xl font-semibold">Settings</h2>
+        <div class="flex items-center justify-between">
+          <span>Dark mode</span>
+          <ToggleSwitch v-model="settings.dark" />
+        </div>
+      </div>
+    </UiDrawer>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import UiDrawer from '@atlas/ui/components/Drawer.vue';
+import ToggleSwitch from '@atlas/ui/components/ToggleSwitch.vue';
+import { useSettings } from '../composables/useSettings';
+
+const visible = ref(false);
+const settings = useSettings();
+</script>
+
+<style scoped>
+</style>

--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <button
-      class="fixed z-50 top-1/2 -right-4 transform -translate-y-1/2 bg-primary-500 text-white p-3 rounded-l shadow flex items-center justify-center"
+      class="fixed z-50 top-1/2 -right-2 transform -translate-y-1/2 bg-primary-500 text-white p-3 rounded-l shadow flex items-center justify-center cursor-pointer"
       @click="visible = true"
     >
       <span class="pi pi-cog"></span>
@@ -11,7 +11,7 @@
         <h2 class="text-xl font-semibold">Settings</h2>
         <div class="flex items-center justify-between">
           <span>Dark mode</span>
-          <ToggleSwitch v-model="settings.dark" />
+          <ToggleSwitch v-model="dark" />
         </div>
       </div>
     </UiDrawer>
@@ -25,7 +25,7 @@ import ToggleSwitch from '@atlas/ui/components/ToggleSwitch.vue';
 import { useSettings } from '../composables/useSettings';
 
 const visible = ref(false);
-const settings = useSettings();
+const { dark } = useSettings();
 </script>
 
 <style scoped>

--- a/playground/src/composables/useSettings.js
+++ b/playground/src/composables/useSettings.js
@@ -1,0 +1,16 @@
+import { ref, watch } from 'vue';
+
+const dark = ref(localStorage.getItem('playground_dark') === 'true');
+
+watch(
+  dark,
+  (value) => {
+    localStorage.setItem('playground_dark', value);
+    document.documentElement.classList.toggle('dark', value);
+  },
+  { immediate: true }
+);
+
+export function useSettings() {
+  return { dark };
+}


### PR DESCRIPTION
## Summary
- add fixed cog tab and slide-out settings drawer to playground
- store dark mode preference in composable and toggle global class

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab4dd8a3f48325bdde96c7eb8b06d2