### PR TITLE
Add FileUpload component and showcase in forms playground

### DIFF
--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -66,6 +66,11 @@
                   <Textarea id="description" v-model="form.description" fluid autoResize />
                 </LabelField>
               </div>
+              <div class="w-full">
+                <LabelField name="file" label="Upload file">
+                  <FileUpload mode="basic" customUpload @select="form.file = $event.files[0]" />
+                </LabelField>
+              </div>
             </div>
           </template>
         </Card>
@@ -125,6 +130,11 @@
               <div class="w-full">
                 <LabelField name="description" label="Description">
                   <Textarea id="description_disabled" v-model="form.description" fluid :disabled="true" autoResize />
+                </LabelField>
+              </div>
+              <div class="w-full">
+                <LabelField name="file" label="Upload file">
+                  <FileUpload mode="basic" customUpload :disabled="true" />
                 </LabelField>
               </div>
             </div>
@@ -241,6 +251,7 @@ import MultiSelect from '@atlas/ui/components/MultiSelect.vue';
 import AutoComplete from '@atlas/ui/components/AutoComplete.vue';
 import DatePicker from '@atlas/ui/components/DatePicker.vue';
 import Textarea from '@atlas/ui/components/Textarea.vue';
+import FileUpload from '@atlas/ui/components/FileUpload.vue';
 import InputNumber from '@atlas/ui/components/InputNumber.vue';
 import Alert from '@atlas/ui/components/Alert.vue';
 import LabelCheckbox from '@atlas/ui/components/LabelCheckbox.vue';
@@ -266,6 +277,7 @@ const form = reactive({
     month: new Date('2024-02-01'),
     time: new Date('2024-01-01T12:00:00'),
     description: 'Example description',
+    file: null,
 });
 
 const roles = ref([

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -5,7 +5,7 @@
         :pt="mergedPt"
         :ptOptions="{ mergeProps: ptViewMerge }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="slotName in slotNames" v-slot:[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </PrimeFileUpload>
@@ -16,7 +16,7 @@ import PrimeFileUpload, {
     type FileUploadProps,
     type FileUploadPassThroughOptions
 } from 'primevue/fileupload';
-import { ref, useAttrs, computed } from 'vue';
+import { ref, useAttrs, computed, useSlots } from 'vue';
 import { ptViewMerge, ptMerge } from '../utils';
 
 defineOptions({ inheritAttrs: false });
@@ -24,6 +24,7 @@ defineOptions({ inheritAttrs: false });
 interface Props extends /* @vue-ignore */ FileUploadProps {}
 const props = defineProps<Props>();
 const attrs = useAttrs();
+const slots = useSlots();
 
 const theme = ref<FileUploadPassThroughOptions>({
     basicContent: 'flex items-center gap-2',
@@ -65,4 +66,5 @@ const passThroughProps = computed(() => {
     return rest;
 });
 const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const slotNames = computed(() => Object.keys(slots).filter((key) => isNaN(Number(key))));
 </script>

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -1,0 +1,59 @@
+<template>
+    <FileUpload
+        unstyled
+        v-bind="bindProps"
+        :pt="mergedPt"
+        :ptOptions="{ mergeProps: ptViewMerge }"
+    />
+</template>
+
+<script setup lang="ts">
+import FileUpload, { type FileUploadProps, type FileUploadPassThroughOptions } from 'primevue/fileupload';
+import { ref, useAttrs, computed } from 'vue';
+import { ptViewMerge, ptMerge } from '../utils';
+
+interface Props extends /* @vue-ignore */ FileUploadProps {}
+const props = defineProps<Props>();
+const attrs = useAttrs();
+
+const theme = ref<FileUploadPassThroughOptions>({
+    basicContent: 'flex items-center gap-2',
+    pcChooseButton: {
+        root: `inline-flex align-middle cursor-pointer select-none items-center justify-center overflow-hidden relative
+        px-4 py-[9px] leading-5 gap-2 rounded disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
+        bg-primary-500 enabled:hover:bg-primary-500/70 enabled:active:bg-primary-500/60 text-white text-md font-semibold p-text:!font-medium
+        border border-primary-500 enabled:hover:border-primary-500/70 enabled:active:border-primary-500/60
+        focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
+        p-vertical:flex-col p-fluid:w-full p-fluid:p-icon-only:w-10 p-fluid:p-icon-only:h-10
+        p-icon-only:w-10 p-icon-only:h-10 p-icon-only:p-0 p-icon-only:gap-0
+        p-icon-only:p-rounded:rounded-full
+        p-small:p-icon-only:w-[34px] p-small:p-icon-only:h-[34px] p-small:p-icon-only:p-0
+        p-large:p-icon-only:w-[42px] p-large:p-icon-only:h-[42px] p-large:p-icon-only:p-0
+        p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
+        p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
+        p-raised:shadow-sm p-rounded:rounded-[2rem]
+        p-outlined:bg-transparent enabled:hover:p-outlined:bg-primary-50 enabled:active:p-outlined:bg-primary-100
+        p-outlined:border-primary-200 enabled:hover:p-outlined:border-primary-200 enabled:active:p-outlined:border-primary-200
+        p-outlined:text-primary enabled:hover:p-outlined:text-primary enabled:active:p-outlined:text-primary
+        dark:p-outlined:bg-transparent dark:enabled:hover:p-outlined:bg-primary/5 dark:enabled:active:p-outlined:bg-primary/15
+        dark:p-outlined:border-primary-300 dark:enabled:hover:p-outlined:border-primary-200 dark:enabled:active:p-outlined:border-primary-500
+        dark:p-outlined:text-primary-300 dark:enabled:hover:p-outlined:text-primary-200 dark:enabled:active:p-outlined:text-primary-200
+        p-text:bg-transparent enabled:hover:p-text:bg-gray-100 enabled:active:p-text:bg-primary-100
+        p-text:border-transparent enabled:hover:p-text:border-transparent enabled:active:p-text:border-transparent
+        p-text:text-gray-700 enabled:hover:p-text:text-gray-700 enabled:active:p-text:text-gray-700
+        dark:p-text:bg-transparent dark:enabled:hover:p-text:bg-primary/5 dark:enabled:active:p-text:bg-primary/15
+        dark:p-text:border-transparent dark:enabled:hover:p-text:border-transparent dark:enabled:active:p-text:border-transparent
+        dark:p-text:text-white dark:enabled:hover:p-text:text-primary dark:enabled:active:p-text:text-primary`,
+        label: 'leading-5 p-icon-only:invisible p-icon-only:w-0 p-large:font-bold',
+        icon: 'p-right:order-1 p-bottom:order-2',
+        loadingIcon: 'animate-spin'
+    }
+});
+
+const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const passThroughProps = computed(() => {
+    const { pt, ...rest } = props as any;
+    return rest;
+});
+const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+</script>

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -1,16 +1,25 @@
 <template>
-    <FileUpload
+    <PrimeFileUpload
         unstyled
         v-bind="bindProps"
         :pt="mergedPt"
         :ptOptions="{ mergeProps: ptViewMerge }"
-    />
+    >
+        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+            <slot :name="slotName" v-bind="slotProps ?? {}" />
+        </template>
+    </PrimeFileUpload>
 </template>
 
 <script setup lang="ts">
-import FileUpload, { type FileUploadProps, type FileUploadPassThroughOptions } from 'primevue/fileupload';
+import PrimeFileUpload, {
+    type FileUploadProps,
+    type FileUploadPassThroughOptions
+} from 'primevue/fileupload';
 import { ref, useAttrs, computed } from 'vue';
 import { ptViewMerge, ptMerge } from '../utils';
+
+defineOptions({ inheritAttrs: false });
 
 interface Props extends /* @vue-ignore */ FileUploadProps {}
 const props = defineProps<Props>();

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -51,6 +51,7 @@ export { default as Pagination } from './Pagination.vue';
 export { default as ProgressBar } from './ProgressBar.vue';
 export { default as ButtonMenu } from './ButtonMenu.vue';
 export { default as DatePicker } from './DatePicker.vue';
+export { default as FileUpload } from './FileUpload.vue';
 export { default as Editor } from './Editor/Index.vue';
 export { default as EditorContent } from './Editor/EditorContent.vue';
 export { default as PageContent } from './App/Page/Content.vue';


### PR DESCRIPTION
## Summary
- add FileUpload component built on PrimeVue FileUpload with Atlas styling
- expose component via library exports
- demonstrate file upload in forms playground with basic mode field

## Testing
- `npm test` (in ui)


------
https://chatgpt.com/codex/tasks/task_b_68ab4eb47e4c83258ccb3103d2512c91