### PR TITLE
feat(playground): toggle top nav layout

### DIFF
--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -13,6 +13,10 @@
           <span>Dark mode</span>
           <ToggleSwitch v-model="dark" />
         </div>
+        <div class="flex items-center justify-between">
+          <span>Top navigation</span>
+          <ToggleSwitch v-model="topNav" />
+        </div>
       </div>
     </UiDrawer>
   </div>
@@ -25,7 +29,7 @@ import ToggleSwitch from '@atlas/ui/components/ToggleSwitch.vue';
 import { useSettings } from '../composables/useSettings';
 
 const visible = ref(false);
-const { dark } = useSettings();
+const { dark, topNav } = useSettings();
 </script>
 
 <style scoped>

--- a/playground/src/composables/useSettings.js
+++ b/playground/src/composables/useSettings.js
@@ -1,6 +1,7 @@
 import { ref, watch } from 'vue';
 
 const dark = ref(localStorage.getItem('playground_dark') === 'true');
+const topNav = ref(localStorage.getItem('playground_top_nav') === 'true');
 
 watch(
   dark,
@@ -11,6 +12,14 @@ watch(
   { immediate: true }
 );
 
+watch(
+  topNav,
+  (value) => {
+    localStorage.setItem('playground_top_nav', value);
+  },
+  { immediate: true }
+);
+
 export function useSettings() {
-  return { dark };
+  return { dark, topNav };
 }

--- a/playground/src/layouts/ComponentsLayout.vue
+++ b/playground/src/layouts/ComponentsLayout.vue
@@ -3,10 +3,11 @@
     :pageUrl="route.fullPath"
     :pageTitle="pageTitle"
     :sideBarItems="sideBarItems"
+    :topBarItems="topBarItems"
     :pageNavItems="pageNavItems"
     :pageTabs="pageTabs"
     :linkComponent="RouterLink"
-    :isSideNav="true"
+    :isSideNav="!topNav"
     :widthClass="'w-full'"
   >
     <template #navLogo>
@@ -22,8 +23,11 @@ import { useRoute, RouterView } from 'vue-router';
 import UiApp from '@atlas/ui/components/App/Index.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
+import { useSettings } from '../composables/useSettings';
 
 const route = useRoute();
+const { topNav } = useSettings();
+const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
 
 const pageNavItems = [
   {

--- a/playground/src/layouts/MainLayout.vue
+++ b/playground/src/layouts/MainLayout.vue
@@ -3,8 +3,9 @@
     :pageUrl="route.fullPath"
     :pageTitle="pageTitle"
     :sideBarItems="sideBarItems"
+    :topBarItems="topBarItems"
     :linkComponent="RouterLink"
-    :isSideNav="true"
+    :isSideNav="!topNav"
     :widthClass="'w-full'"
   >
     <template #navLogo>
@@ -20,7 +21,10 @@ import { useRoute, RouterView } from 'vue-router';
 import UiApp from '@atlas/ui/components/App/Index.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
+import { useSettings } from '../composables/useSettings';
 
 const route = useRoute();
 const pageTitle = computed(() => route.meta.title || '');
+const { topNav } = useSettings();
+const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
 </script>

--- a/playground/src/layouts/UserLayout.vue
+++ b/playground/src/layouts/UserLayout.vue
@@ -4,9 +4,10 @@
         :pageUrl="route.fullPath"
         :pageTitle="'User'"
         :sideBarItems="sideBarItems"
+        :topBarItems="topBarItems"
         :linkComponent="Link"
         :widthClass="'w-full'"
-        :isSideNav="true"
+        :isSideNav="!topNav"
     >
         <template #navLogo>
             <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
@@ -49,12 +50,14 @@
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import LayoutApp from '@atlas/ui/components/App/Index.vue';
 import { Button, useModal } from '@atlas/ui';
 import UserModals from '../components/UserModals.vue';
 import Link from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
+import { useSettings } from '../composables/useSettings';
 
 const props = defineProps({
     item: {
@@ -65,4 +68,6 @@ const props = defineProps({
 
 const { open } = useModal();
 const route = useRoute();
+const { topNav } = useSettings();
+const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
 </script>

--- a/playground/src/layouts/UsersLayout.vue
+++ b/playground/src/layouts/UsersLayout.vue
@@ -3,9 +3,10 @@
     :pageUrl="route.fullPath"
     :pageTitle="pageTitle"
     :sideBarItems="sideBarItems"
+    :topBarItems="topBarItems"
     :linkComponent="RouterLink"
     :widthClass="'w-full'"
-    :isSideNav="true"
+    :isSideNav="!topNav"
   >
     <template #navLogo>
       <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
@@ -20,7 +21,10 @@ import { useRoute, RouterView } from 'vue-router';
 import UiApp from '@atlas/ui/components/App/Index.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
+import { useSettings } from '../composables/useSettings';
 
 const route = useRoute();
 const pageTitle = computed(() => route.meta.title || '');
+const { topNav } = useSettings();
+const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
 </script>

--- a/playground/src/pages/Users.vue
+++ b/playground/src/pages/Users.vue
@@ -5,8 +5,9 @@
         containerClass="p-0"
         :noScroll="true"
         :sideBarItems="sideBarItems"
+        :topBarItems="topBarItems"
         :linkComponent="Link"
-        :isSideNav="true"
+        :isSideNav="!topNav"
         :widthClass="'w-full'"
     >
         <template #navLogo>
@@ -97,8 +98,11 @@ import UserModals from '../components/UserModals.vue';
 import Link from '../components/RouterLink.vue';
 import LinkPaginator from '../components/LinkPaginator.vue';
 import { sideBarItems } from '../sideBarItems';
+import { useSettings } from '../composables/useSettings';
 
 const { open } = useModal();
+const { topNav } = useSettings();
+const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
 
 const tableActionMenuItems = ref([
     { label: 'Edit', action: 'edit' },


### PR DESCRIPTION
## Summary
- add Top navigation toggle in the settings drawer
- persist layout preference in `useSettings`
- update app layouts to switch between sidebar and topbar navigation

## Testing
- `npm test`
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab525418dc8325af589378b33c8930