### PR TITLE
feat(playground): show profile menu across layouts

### DIFF
--- a/playground/src/composables/useProfileMenu.js
+++ b/playground/src/composables/useProfileMenu.js
@@ -1,0 +1,25 @@
+import { ref, computed } from 'vue';
+
+const user = ref({
+  id: 1,
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+});
+
+const profileMenuItems = computed(() => [
+  { separator: true },
+  { label: 'Company Name', icon: 'pi pi-building-columns', href: '/' },
+  { separator: true },
+  { label: 'Billing & Plan', icon: 'pi pi-credit-card', href: '/' },
+  { label: 'Manage Access', icon: 'pi pi-users', href: '/' },
+  { label: 'Integrations', icon: 'pi pi-objects-column', href: '/' },
+  { label: 'Settings', icon: 'pi pi-cog', href: '/' },
+  { label: 'Status page', icon: 'pi pi-cog', href: 'https://google.com', external: true },
+  { separator: true },
+  { label: 'Logout', icon: 'pi pi-sign-out', href: '/logout' },
+]);
+
+export function useProfileMenu() {
+  return { user, profileMenuItems };
+}
+

--- a/playground/src/layouts/ComponentsLayout.vue
+++ b/playground/src/layouts/ComponentsLayout.vue
@@ -13,6 +13,15 @@
     <template #navLogo>
       <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
     </template>
+    <template #navActions>
+      <ProfileMenu
+        :user="user"
+        :items="profileMenuItems"
+        :avatar-only="true"
+        headerLink="/"
+        :linkComponent="RouterLink"
+      />
+    </template>
     <RouterView />
   </UiApp>
 </template>
@@ -21,13 +30,16 @@
 import { computed } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
 import UiApp from '@atlas/ui/components/App/Index.vue';
+import ProfileMenu from '@atlas/ui/components/App/Nav/ProfileMenu.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 import { useSettings } from '../composables/useSettings';
+import { useProfileMenu } from '../composables/useProfileMenu';
 
 const route = useRoute();
 const { topNav } = useSettings();
 const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
+const { user, profileMenuItems } = useProfileMenu();
 
 const pageNavItems = [
   {

--- a/playground/src/layouts/MainLayout.vue
+++ b/playground/src/layouts/MainLayout.vue
@@ -25,35 +25,19 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
 import UiApp from '@atlas/ui/components/App/Index.vue';
 import ProfileMenu from '@atlas/ui/components/App/Nav/ProfileMenu.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 import { useSettings } from '../composables/useSettings';
+import { useProfileMenu } from '../composables/useProfileMenu';
 
 const route = useRoute();
 const pageTitle = computed(() => route.meta.title || '');
 
-const user = ref({
-  id: 1,
-  name: 'Jane Doe',
-  email: 'jane@example.com'
-});
-
-const profileMenuItems = computed(() => [
-  { separator: true },
-  { label: 'Company Name', icon: 'pi pi-building-columns', href: '/' },
-  { separator: true },
-  { label: 'Billing & Plan', icon: 'pi pi-credit-card', href: '/' },
-  { label: 'Manage Access', icon: 'pi pi-users', href: '/' },
-  { label: 'Integrations', icon: 'pi pi-objects-column', href: '/' },
-  { label: 'Settings', icon: 'pi pi-cog', href: '/' },
-  { label: 'Status page', icon: 'pi pi-cog', href: 'https://google.com', external: true },
-  { separator: true },
-  { label: 'Logout', icon: 'pi pi-sign-out', href: '/logout' }
-]);
+const { user, profileMenuItems } = useProfileMenu();
 const { topNav } = useSettings();
 const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
 </script>

--- a/playground/src/layouts/UserLayout.vue
+++ b/playground/src/layouts/UserLayout.vue
@@ -12,6 +12,15 @@
         <template #navLogo>
             <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
         </template>
+        <template #navActions>
+            <ProfileMenu
+                :user="user"
+                :items="profileMenuItems"
+                :avatar-only="true"
+                headerLink="/"
+                :linkComponent="Link"
+            />
+        </template>
         <template #headerTitle>
             <div class="pr-2">
                 <Button
@@ -53,11 +62,13 @@
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import LayoutApp from '@atlas/ui/components/App/Index.vue';
+import ProfileMenu from '@atlas/ui/components/App/Nav/ProfileMenu.vue';
 import { Button, useModal } from '@atlas/ui';
 import UserModals from '../components/UserModals.vue';
 import Link from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 import { useSettings } from '../composables/useSettings';
+import { useProfileMenu } from '../composables/useProfileMenu';
 
 const props = defineProps({
     item: {
@@ -70,4 +81,5 @@ const { open } = useModal();
 const route = useRoute();
 const { topNav } = useSettings();
 const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
+const { user, profileMenuItems } = useProfileMenu();
 </script>

--- a/playground/src/layouts/UsersLayout.vue
+++ b/playground/src/layouts/UsersLayout.vue
@@ -11,6 +11,15 @@
     <template #navLogo>
       <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
     </template>
+    <template #navActions>
+      <ProfileMenu
+        :user="user"
+        :items="profileMenuItems"
+        :avatar-only="true"
+        headerLink="/"
+        :linkComponent="RouterLink"
+      />
+    </template>
     <RouterView />
   </UiApp>
 </template>
@@ -19,12 +28,15 @@
 import { computed } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
 import UiApp from '@atlas/ui/components/App/Index.vue';
+import ProfileMenu from '@atlas/ui/components/App/Nav/ProfileMenu.vue';
 import RouterLink from '../components/RouterLink.vue';
 import { sideBarItems } from '../sideBarItems';
 import { useSettings } from '../composables/useSettings';
+import { useProfileMenu } from '../composables/useProfileMenu';
 
 const route = useRoute();
 const pageTitle = computed(() => route.meta.title || '');
 const { topNav } = useSettings();
 const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
+const { user, profileMenuItems } = useProfileMenu();
 </script>

--- a/playground/src/pages/Users.vue
+++ b/playground/src/pages/Users.vue
@@ -13,6 +13,15 @@
         <template #navLogo>
             <img src="/atlas.png" alt="Atlas" class="h-8 w-8 rounded-full" />
         </template>
+        <template #navActions>
+            <ProfileMenu
+                :user="user"
+                :items="profileMenuItems"
+                :avatar-only="true"
+                headerLink="/"
+                :linkComponent="Link"
+            />
+        </template>
         <template v-if="(selectAll ? userTotal : selected?.length) > 0" #headerTitle>
             <TableActions
                 :selectedCount="selectAll ? userTotal : selected?.length"
@@ -93,16 +102,19 @@
 <script setup>
 import { ref, computed } from 'vue';
 import LayoutApp from '@atlas/ui/components/App/Index.vue';
+import ProfileMenu from '@atlas/ui/components/App/Nav/ProfileMenu.vue';
 import { Table, ButtonMenu, TableActions, InputText, Button, Select, useModal } from '@atlas/ui';
 import UserModals from '../components/UserModals.vue';
 import Link from '../components/RouterLink.vue';
 import LinkPaginator from '../components/LinkPaginator.vue';
 import { sideBarItems } from '../sideBarItems';
 import { useSettings } from '../composables/useSettings';
+import { useProfileMenu } from '../composables/useProfileMenu';
 
 const { open } = useModal();
 const { topNav } = useSettings();
 const topBarItems = computed(() => sideBarItems.flatMap((section) => section.children));
+const { user, profileMenuItems } = useProfileMenu();
 
 const tableActionMenuItems = ref([
     { label: 'Edit', action: 'edit' },


### PR DESCRIPTION
## Summary
- add shared profile menu data
- include profile menu in all layouts and users page

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ab58ad3f6c8325ae782fb78ddb3aa2