### PR TITLE
docs: add profile menu items example

### DIFF
--- a/docs/ui/application/profile-menu.md
+++ b/docs/ui/application/profile-menu.md
@@ -4,7 +4,21 @@ User avatar dropdown menu for account actions.
 
 ## Example
 ```ts
+import { computed } from 'vue';
 import { ProfileMenu } from '@atlas/ui';
+
+const profileMenuItems = computed(() => [
+  { separator: true },
+  { label: 'Company Name', icon: 'pi pi-building-columns', href: '/' },
+  { separator: true },
+  { label: 'Billing & Plan', icon: 'pi pi-credit-card', href: '/' },
+  { label: 'Manage Access', icon: 'pi pi-users', href: '/' },
+  { label: 'Integrations', icon: 'pi pi-objects-column', href: '/' },
+  { label: 'Settings', icon: 'pi pi-cog', href: '/' },
+  { label: 'Status page', icon: 'pi pi-cog', href: 'https://google.com', external: true },
+  { separator: true },
+  { label: 'Logout', icon: 'pi pi-sign-out', href: '/logout' }
+]);
 ```
 
 ```vue


### PR DESCRIPTION
## Summary
- add computed profile menu items example to ProfileMenu docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab5bc235cc8325bf50f0cf0f33d420