### PR TITLE
feat(playground): add theme selector

### DIFF
--- a/playground/src/base.css
+++ b/playground/src/base.css
@@ -1,33 +1,6 @@
-
 /* Primary and Surface Palettes */
-/* :root {
-    --p-primary-50: #ecfdf5;
-    --p-primary-100: #d1fae5;
-    --p-primary-200: #a7f3d0;
-    --p-primary-300: #6ee7b7;
-    --p-primary-400: #34d399;
-    --p-primary-500: #10b981;
-    --p-primary-600: #059669;
-    --p-primary-700: #047857;
-    --p-primary-800: #065f46;
-    --p-primary-900: #064e3b;
-    --p-primary-950: #022c22;
-    --p-surface-0: #ffffff;
-    --p-surface-50: #fafafa;
-    --p-surface-100: #f4f4f5;
-    --p-surface-200: #e4e4e7;
-    --p-surface-300: #d4d4d8;
-    --p-surface-400: #a1a1aa;
-    --p-surface-500: #71717a;
-    --p-surface-600: #52525b;
-    --p-surface-700: #3f3f46;
-    --p-surface-800: #27272a;
-    --p-surface-900: #18181b;
-    --p-surface-950: #09090b;
-    --p-content-border-radius: 6px;
-} */
-
-:root {
+:root,
+.theme-blue {
     --p-primary-50: #dbeafe;
     --p-primary-100: #bfdbfe;
     --p-primary-200: #93c5fd;
@@ -40,59 +13,6 @@
     --p-primary-900: #172554;
     --p-primary-950: #0f172a;
 
-    /* SLATE */
-    /* --p-primary-50:  #f8fafc;
-    --p-primary-100: #f1f5f9;
-    --p-primary-200: #e2e8f0;
-    --p-primary-300: #cbd5e1;
-    --p-primary-400: #94a3b8;
-    --p-primary-500: #64748b;
-    --p-primary-600: #475569;
-    --p-primary-700: #334155;
-    --p-primary-800: #1e293b;
-    --p-primary-900: #0f172a;
-    --p-primary-950: #020617; */
-
-    /* BLACK */
-    /* --p-primary-50:  #f5f5f5;
-    --p-primary-100: #e5e5e5;
-    --p-primary-200: #d4d4d4;
-    --p-primary-300: #a3a3a3;
-    --p-primary-400: #333333;
-    --p-primary-500: #000000;
-    --p-primary-600: #000000;
-    --p-primary-700: #000000;
-    --p-primary-800: #000000;
-    --p-primary-900: #000000;
-    --p-primary-950: #000000; */
-
-    /* PINK */
-    /* --p-primary-50:  #fff0f7;
-    --p-primary-100: #ffe0ef;
-    --p-primary-200: #fab8d7;
-    --p-primary-300: #f78fc0;
-    --p-primary-400: #f666ae;
-    --p-primary-500: #fc4ba8;
-    --p-primary-600: #e03c93;
-    --p-primary-700: #c1327d;
-    --p-primary-800: #a22868;
-    --p-primary-900: #801e52;
-    --p-primary-950: #4d0f30; */
-
-    /* --p-surface-0:   #ffffff;
-    --p-surface-50:  #fff7fa;
-    --p-surface-100: #feeff6;
-    --p-surface-200: #fde1ec;
-    --p-surface-300: #fbc8dc;
-    --p-surface-400: #f5a3c3;
-    --p-surface-500: #e97daa;
-    --p-surface-600: #d26494;
-    --p-surface-700: #ae4f77;
-    --p-surface-800: #8a3b5c;
-    --p-surface-900: #662941;
-    --p-surface-950: #451928; */
-
-    /* SLATE */
     --p-surface-0: #ffffff;
     --p-surface-50: #f8fafc;
     --p-surface-100: #f1f5f9;
@@ -106,21 +26,104 @@
     --p-surface-900: #0f172a;
     --p-surface-950: #020617;
 
-    /* GRAY */
-    /* --p-surface-0:    #ffffff;
-    --p-surface-50:   #f9fafb;
-    --p-surface-100:  #f3f4f6;
-    --p-surface-200:  #e5e7eb;
-    --p-surface-300:  #d1d5db;
-    --p-surface-400:  #9ca3af;
-    --p-surface-500:  #6b7280;
-    --p-surface-600:  #4b5563;
-    --p-surface-700:  #374151;
-    --p-surface-800:  #1f2937;
-    --p-surface-900:  #111827;
-    --p-surface-950:  #030712; */
-
     --p-content-border-radius: 6px;
+}
+
+.theme-purple {
+    --p-primary-50: #faf5ff;
+    --p-primary-100: #f3e8ff;
+    --p-primary-200: #e9d5ff;
+    --p-primary-300: #d8b4fe;
+    --p-primary-400: #c084fc;
+    --p-primary-500: #a855f7;
+    --p-primary-600: #9333ea;
+    --p-primary-700: #7e22ce;
+    --p-primary-800: #6b21a8;
+    --p-primary-900: #581c87;
+    --p-primary-950: #3b0764;
+}
+
+.theme-teal {
+    --p-primary-50: #f0fdfa;
+    --p-primary-100: #ccfbf1;
+    --p-primary-200: #99f6e4;
+    --p-primary-300: #5eead4;
+    --p-primary-400: #2dd4bf;
+    --p-primary-500: #14b8a6;
+    --p-primary-600: #0d9488;
+    --p-primary-700: #0f766e;
+    --p-primary-800: #115e59;
+    --p-primary-900: #134e4a;
+    --p-primary-950: #042f2e;
+}
+
+.theme-pink {
+    --p-primary-50: #fdf2f8;
+    --p-primary-100: #fce7f3;
+    --p-primary-200: #fbcfe8;
+    --p-primary-300: #f9a8d4;
+    --p-primary-400: #f472b6;
+    --p-primary-500: #ec4899;
+    --p-primary-600: #db2777;
+    --p-primary-700: #be185d;
+    --p-primary-800: #9d174d;
+    --p-primary-900: #831843;
+    --p-primary-950: #500724;
+}
+
+.theme-gray {
+    --p-primary-50: #f9fafb;
+    --p-primary-100: #f3f4f6;
+    --p-primary-200: #e5e7eb;
+    --p-primary-300: #d1d5db;
+    --p-primary-400: #9ca3af;
+    --p-primary-500: #6b7280;
+    --p-primary-600: #4b5563;
+    --p-primary-700: #374151;
+    --p-primary-800: #1f2937;
+    --p-primary-900: #111827;
+    --p-primary-950: #030712;
+
+    --p-surface-0: #ffffff;
+    --p-surface-50: #f9fafb;
+    --p-surface-100: #f3f4f6;
+    --p-surface-200: #e5e7eb;
+    --p-surface-300: #d1d5db;
+    --p-surface-400: #9ca3af;
+    --p-surface-500: #6b7280;
+    --p-surface-600: #4b5563;
+    --p-surface-700: #374151;
+    --p-surface-800: #1f2937;
+    --p-surface-900: #111827;
+    --p-surface-950: #030712;
+}
+
+.theme-green {
+    --p-primary-50: #f0fdf4;
+    --p-primary-100: #dcfce7;
+    --p-primary-200: #bbf7d0;
+    --p-primary-300: #86efac;
+    --p-primary-400: #4ade80;
+    --p-primary-500: #22c55e;
+    --p-primary-600: #16a34a;
+    --p-primary-700: #15803d;
+    --p-primary-800: #166534;
+    --p-primary-900: #14532d;
+    --p-primary-950: #052e16;
+}
+
+.theme-orange {
+    --p-primary-50: #fff7ed;
+    --p-primary-100: #ffedd5;
+    --p-primary-200: #fed7aa;
+    --p-primary-300: #fdba74;
+    --p-primary-400: #fb923c;
+    --p-primary-500: #f97316;
+    --p-primary-600: #ea580c;
+    --p-primary-700: #c2410c;
+    --p-primary-800: #9a3412;
+    --p-primary-900: #7c2d12;
+    --p-primary-950: #431407;
 }
 
 /* Light */

--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -17,6 +17,17 @@
           <span>Top navigation</span>
           <ToggleSwitch v-model="topNav" />
         </div>
+        <div class="flex items-center justify-between">
+          <span>Theme</span>
+          <Select
+            v-model="theme"
+            :options="themeOptions"
+            option-label="label"
+            option-value="value"
+            class="w-40"
+            size="small"
+          />
+        </div>
       </div>
     </UiDrawer>
   </div>
@@ -26,10 +37,20 @@
 import { ref } from 'vue';
 import UiDrawer from '@atlas/ui/components/Drawer.vue';
 import ToggleSwitch from '@atlas/ui/components/ToggleSwitch.vue';
+import Select from '@atlas/ui/components/Select.vue';
 import { useSettings } from '../composables/useSettings';
 
 const visible = ref(false);
-const { dark, topNav } = useSettings();
+const { dark, topNav, theme } = useSettings();
+const themeOptions = [
+  { label: 'Blue', value: 'blue' },
+  { label: 'Purple', value: 'purple' },
+  { label: 'Teal', value: 'teal' },
+  { label: 'Pink', value: 'pink' },
+  { label: 'Gray', value: 'gray' },
+  { label: 'Green', value: 'green' },
+  { label: 'Orange', value: 'orange' },
+];
 </script>
 
 <style scoped>

--- a/playground/src/composables/useSettings.js
+++ b/playground/src/composables/useSettings.js
@@ -2,6 +2,8 @@ import { ref, watch } from 'vue';
 
 const dark = ref(localStorage.getItem('playground_dark') === 'true');
 const topNav = ref(localStorage.getItem('playground_top_nav') === 'true');
+const theme = ref(localStorage.getItem('playground_theme') || 'blue');
+const themes = ['blue', 'purple', 'teal', 'pink', 'gray', 'green', 'orange'];
 
 watch(
   dark,
@@ -20,6 +22,18 @@ watch(
   { immediate: true }
 );
 
+watch(
+  theme,
+  (value) => {
+    localStorage.setItem('playground_theme', value);
+    document.documentElement.classList.remove(
+      ...themes.map((t) => `theme-${t}`)
+    );
+    document.documentElement.classList.add(`theme-${value}`);
+  },
+  { immediate: true }
+);
+
 export function useSettings() {
-  return { dark, topNav };
+  return { dark, topNav, theme };
 }


### PR DESCRIPTION
## Summary
- add theme selector to playground settings
- persist theme in local storage and apply palette classes
- define palettes for blue, purple, teal, pink, gray, green, and orange

## Testing
- `npm test` *(playground)* *(fails: Missing script "test")*
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68ab5c77b8ec832581aae0da8b391bd1