### PR TITLE
feat(playground): add primary and surface theme selectors

### DIFF
--- a/playground/src/base.css
+++ b/playground/src/base.css
@@ -28,6 +28,20 @@
     --p-primary-950: #3b0764;
 }
 
+.theme-primary-indigo {
+    --p-primary-50: #eef2ff;
+    --p-primary-100: #e0e7ff;
+    --p-primary-200: #c7d2fe;
+    --p-primary-300: #a5b4fc;
+    --p-primary-400: #818cf8;
+    --p-primary-500: #6366f1;
+    --p-primary-600: #4f46e5;
+    --p-primary-700: #4338ca;
+    --p-primary-800: #3730a3;
+    --p-primary-900: #312e81;
+    --p-primary-950: #1e1b4b;
+}
+
 .theme-primary-teal {
     --p-primary-50: #f0fdfa;
     --p-primary-100: #ccfbf1;
@@ -57,17 +71,17 @@
 }
 
 .theme-primary-gray {
-    --p-primary-50: #f9fafb;
-    --p-primary-100: #f3f4f6;
-    --p-primary-200: #e5e7eb;
-    --p-primary-300: #d1d5db;
-    --p-primary-400: #9ca3af;
-    --p-primary-500: #6b7280;
-    --p-primary-600: #4b5563;
-    --p-primary-700: #374151;
-    --p-primary-800: #1f2937;
-    --p-primary-900: #111827;
-    --p-primary-950: #030712;
+    --p-primary-50: #fafafa;
+    --p-primary-100: #f4f4f5;
+    --p-primary-200: #e4e4e7;
+    --p-primary-300: #d4d4d8;
+    --p-primary-400: #a1a1aa;
+    --p-primary-500: #000000;
+    --p-primary-600: #52525b;
+    --p-primary-700: #3f3f46;
+    --p-primary-800: #27272a;
+    --p-primary-900: #18181b;
+    --p-primary-950: #09090b;
 }
 
 .theme-primary-green {
@@ -130,6 +144,66 @@
     --p-surface-800: #1f2937;
     --p-surface-900: #111827;
     --p-surface-950: #030712;
+}
+
+.theme-surface-purple {
+    --p-surface-0: #ffffff;
+    --p-surface-50: #faf5ff;
+    --p-surface-100: #f3e8ff;
+    --p-surface-200: #e9d5ff;
+    --p-surface-300: #d8b4fe;
+    --p-surface-400: #c084fc;
+    --p-surface-500: #a855f7;
+    --p-surface-600: #9333ea;
+    --p-surface-700: #7e22ce;
+    --p-surface-800: #6b21a8;
+    --p-surface-900: #581c87;
+    --p-surface-950: #3b0764;
+}
+
+.theme-surface-pink {
+    --p-surface-0: #ffffff;
+    --p-surface-50: #fdf2f8;
+    --p-surface-100: #fce7f3;
+    --p-surface-200: #fbcfe8;
+    --p-surface-300: #f9a8d4;
+    --p-surface-400: #f472b6;
+    --p-surface-500: #ec4899;
+    --p-surface-600: #db2777;
+    --p-surface-700: #be185d;
+    --p-surface-800: #9d174d;
+    --p-surface-900: #831843;
+    --p-surface-950: #500724;
+}
+
+.theme-surface-slate {
+    --p-surface-0: #ffffff;
+    --p-surface-50: #f8fafc;
+    --p-surface-100: #f1f5f9;
+    --p-surface-200: #e2e8f0;
+    --p-surface-300: #cbd5e1;
+    --p-surface-400: #94a3b8;
+    --p-surface-500: #64748b;
+    --p-surface-600: #475569;
+    --p-surface-700: #334155;
+    --p-surface-800: #1e293b;
+    --p-surface-900: #0f172a;
+    --p-surface-950: #020617;
+}
+
+.theme-surface-zinc {
+    --p-surface-0: #ffffff;
+    --p-surface-50: #fafafa;
+    --p-surface-100: #f4f4f5;
+    --p-surface-200: #e4e4e7;
+    --p-surface-300: #d4d4d8;
+    --p-surface-400: #a1a1aa;
+    --p-surface-500: #71717a;
+    --p-surface-600: #52525b;
+    --p-surface-700: #3f3f46;
+    --p-surface-800: #27272a;
+    --p-surface-900: #18181b;
+    --p-surface-950: #09090b;
 }
 
 /* Light */

--- a/playground/src/base.css
+++ b/playground/src/base.css
@@ -1,6 +1,6 @@
-/* Primary and Surface Palettes */
+/* Primary Palettes */
 :root,
-.theme-blue {
+.theme-primary-blue {
     --p-primary-50: #dbeafe;
     --p-primary-100: #bfdbfe;
     --p-primary-200: #93c5fd;
@@ -12,7 +12,95 @@
     --p-primary-800: #1e3a8a;
     --p-primary-900: #172554;
     --p-primary-950: #0f172a;
+}
 
+.theme-primary-purple {
+    --p-primary-50: #faf5ff;
+    --p-primary-100: #f3e8ff;
+    --p-primary-200: #e9d5ff;
+    --p-primary-300: #d8b4fe;
+    --p-primary-400: #c084fc;
+    --p-primary-500: #a855f7;
+    --p-primary-600: #9333ea;
+    --p-primary-700: #7e22ce;
+    --p-primary-800: #6b21a8;
+    --p-primary-900: #581c87;
+    --p-primary-950: #3b0764;
+}
+
+.theme-primary-teal {
+    --p-primary-50: #f0fdfa;
+    --p-primary-100: #ccfbf1;
+    --p-primary-200: #99f6e4;
+    --p-primary-300: #5eead4;
+    --p-primary-400: #2dd4bf;
+    --p-primary-500: #14b8a6;
+    --p-primary-600: #0d9488;
+    --p-primary-700: #0f766e;
+    --p-primary-800: #115e59;
+    --p-primary-900: #134e4a;
+    --p-primary-950: #042f2e;
+}
+
+.theme-primary-pink {
+    --p-primary-50: #fdf2f8;
+    --p-primary-100: #fce7f3;
+    --p-primary-200: #fbcfe8;
+    --p-primary-300: #f9a8d4;
+    --p-primary-400: #f472b6;
+    --p-primary-500: #ec4899;
+    --p-primary-600: #db2777;
+    --p-primary-700: #be185d;
+    --p-primary-800: #9d174d;
+    --p-primary-900: #831843;
+    --p-primary-950: #500724;
+}
+
+.theme-primary-gray {
+    --p-primary-50: #f9fafb;
+    --p-primary-100: #f3f4f6;
+    --p-primary-200: #e5e7eb;
+    --p-primary-300: #d1d5db;
+    --p-primary-400: #9ca3af;
+    --p-primary-500: #6b7280;
+    --p-primary-600: #4b5563;
+    --p-primary-700: #374151;
+    --p-primary-800: #1f2937;
+    --p-primary-900: #111827;
+    --p-primary-950: #030712;
+}
+
+.theme-primary-green {
+    --p-primary-50: #f0fdf4;
+    --p-primary-100: #dcfce7;
+    --p-primary-200: #bbf7d0;
+    --p-primary-300: #86efac;
+    --p-primary-400: #4ade80;
+    --p-primary-500: #22c55e;
+    --p-primary-600: #16a34a;
+    --p-primary-700: #15803d;
+    --p-primary-800: #166534;
+    --p-primary-900: #14532d;
+    --p-primary-950: #052e16;
+}
+
+.theme-primary-orange {
+    --p-primary-50: #fff7ed;
+    --p-primary-100: #ffedd5;
+    --p-primary-200: #fed7aa;
+    --p-primary-300: #fdba74;
+    --p-primary-400: #fb923c;
+    --p-primary-500: #f97316;
+    --p-primary-600: #ea580c;
+    --p-primary-700: #c2410c;
+    --p-primary-800: #9a3412;
+    --p-primary-900: #7c2d12;
+    --p-primary-950: #431407;
+}
+
+/* Surface Palettes */
+:root,
+.theme-surface-blue {
     --p-surface-0: #ffffff;
     --p-surface-50: #f8fafc;
     --p-surface-100: #f1f5f9;
@@ -29,61 +117,7 @@
     --p-content-border-radius: 6px;
 }
 
-.theme-purple {
-    --p-primary-50: #faf5ff;
-    --p-primary-100: #f3e8ff;
-    --p-primary-200: #e9d5ff;
-    --p-primary-300: #d8b4fe;
-    --p-primary-400: #c084fc;
-    --p-primary-500: #a855f7;
-    --p-primary-600: #9333ea;
-    --p-primary-700: #7e22ce;
-    --p-primary-800: #6b21a8;
-    --p-primary-900: #581c87;
-    --p-primary-950: #3b0764;
-}
-
-.theme-teal {
-    --p-primary-50: #f0fdfa;
-    --p-primary-100: #ccfbf1;
-    --p-primary-200: #99f6e4;
-    --p-primary-300: #5eead4;
-    --p-primary-400: #2dd4bf;
-    --p-primary-500: #14b8a6;
-    --p-primary-600: #0d9488;
-    --p-primary-700: #0f766e;
-    --p-primary-800: #115e59;
-    --p-primary-900: #134e4a;
-    --p-primary-950: #042f2e;
-}
-
-.theme-pink {
-    --p-primary-50: #fdf2f8;
-    --p-primary-100: #fce7f3;
-    --p-primary-200: #fbcfe8;
-    --p-primary-300: #f9a8d4;
-    --p-primary-400: #f472b6;
-    --p-primary-500: #ec4899;
-    --p-primary-600: #db2777;
-    --p-primary-700: #be185d;
-    --p-primary-800: #9d174d;
-    --p-primary-900: #831843;
-    --p-primary-950: #500724;
-}
-
-.theme-gray {
-    --p-primary-50: #f9fafb;
-    --p-primary-100: #f3f4f6;
-    --p-primary-200: #e5e7eb;
-    --p-primary-300: #d1d5db;
-    --p-primary-400: #9ca3af;
-    --p-primary-500: #6b7280;
-    --p-primary-600: #4b5563;
-    --p-primary-700: #374151;
-    --p-primary-800: #1f2937;
-    --p-primary-900: #111827;
-    --p-primary-950: #030712;
-
+.theme-surface-gray {
     --p-surface-0: #ffffff;
     --p-surface-50: #f9fafb;
     --p-surface-100: #f3f4f6;
@@ -96,34 +130,6 @@
     --p-surface-800: #1f2937;
     --p-surface-900: #111827;
     --p-surface-950: #030712;
-}
-
-.theme-green {
-    --p-primary-50: #f0fdf4;
-    --p-primary-100: #dcfce7;
-    --p-primary-200: #bbf7d0;
-    --p-primary-300: #86efac;
-    --p-primary-400: #4ade80;
-    --p-primary-500: #22c55e;
-    --p-primary-600: #16a34a;
-    --p-primary-700: #15803d;
-    --p-primary-800: #166534;
-    --p-primary-900: #14532d;
-    --p-primary-950: #052e16;
-}
-
-.theme-orange {
-    --p-primary-50: #fff7ed;
-    --p-primary-100: #ffedd5;
-    --p-primary-200: #fed7aa;
-    --p-primary-300: #fdba74;
-    --p-primary-400: #fb923c;
-    --p-primary-500: #f97316;
-    --p-primary-600: #ea580c;
-    --p-primary-700: #c2410c;
-    --p-primary-800: #9a3412;
-    --p-primary-900: #7c2d12;
-    --p-primary-950: #431407;
 }
 
 /* Light */

--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -6,50 +6,66 @@
     >
       <span class="pi pi-cog"></span>
     </button>
-    <UiDrawer v-model:visible="visible" position="right" :modal="false">
-      <div class="p-4 space-y-4">
-        <h2 class="text-xl font-semibold">Settings</h2>
-        <div class="flex items-center justify-between">
-          <span>Dark mode</span>
-          <ToggleSwitch v-model="dark" />
+      <UiDrawer v-model:visible="visible" position="right" :modal="false">
+        <div class="p-4 space-y-4">
+          <h2 class="text-xl font-semibold">Settings</h2>
+          <div class="flex items-center justify-between">
+            <span>Dark mode</span>
+            <ToggleSwitch v-model="dark" />
+          </div>
+          <div class="flex items-center justify-between">
+            <span>Top navigation</span>
+            <ToggleSwitch v-model="topNav" />
+          </div>
+          <div>
+            <span class="block mb-2">Primary</span>
+            <div class="flex gap-2">
+              <button
+                v-for="option in primaryOptions"
+                :key="option.value"
+                :class="['w-6 h-6 rounded-full border cursor-pointer', option.class, primary === option.value ? 'ring-2 ring-offset-2 ring-primary-500' : '']"
+                @click="primary = option.value"
+                :aria-label="option.label"
+              ></button>
+            </div>
+          </div>
+          <div>
+            <span class="block mb-2">Surface</span>
+            <div class="flex gap-2">
+              <button
+                v-for="option in surfaceOptions"
+                :key="option.value"
+                :class="['w-6 h-6 rounded-full border cursor-pointer', option.class, surface === option.value ? 'ring-2 ring-offset-2 ring-primary-500' : '']"
+                @click="surface = option.value"
+                :aria-label="option.label"
+              ></button>
+            </div>
+          </div>
         </div>
-        <div class="flex items-center justify-between">
-          <span>Top navigation</span>
-          <ToggleSwitch v-model="topNav" />
-        </div>
-        <div class="flex items-center justify-between">
-          <span>Theme</span>
-          <Select
-            v-model="theme"
-            :options="themeOptions"
-            option-label="label"
-            option-value="value"
-            class="w-40"
-            size="small"
-          />
-        </div>
-      </div>
-    </UiDrawer>
-  </div>
-</template>
+      </UiDrawer>
+    </div>
+  </template>
 
 <script setup>
 import { ref } from 'vue';
 import UiDrawer from '@atlas/ui/components/Drawer.vue';
 import ToggleSwitch from '@atlas/ui/components/ToggleSwitch.vue';
-import Select from '@atlas/ui/components/Select.vue';
 import { useSettings } from '../composables/useSettings';
 
 const visible = ref(false);
-const { dark, topNav, theme } = useSettings();
-const themeOptions = [
-  { label: 'Blue', value: 'blue' },
-  { label: 'Purple', value: 'purple' },
-  { label: 'Teal', value: 'teal' },
-  { label: 'Pink', value: 'pink' },
-  { label: 'Gray', value: 'gray' },
-  { label: 'Green', value: 'green' },
-  { label: 'Orange', value: 'orange' },
+const { dark, topNav, primary, surface } = useSettings();
+const primaryOptions = [
+    { label: 'Blue', value: 'blue', class: 'bg-blue-500' },
+    { label: 'Purple', value: 'purple', class: 'bg-purple-500' },
+    { label: 'Teal', value: 'teal', class: 'bg-teal-500' },
+    { label: 'Pink', value: 'pink', class: 'bg-pink-500' },
+    { label: 'Gray', value: 'gray', class: 'bg-gray-500' },
+    { label: 'Green', value: 'green', class: 'bg-green-500' },
+    { label: 'Orange', value: 'orange', class: 'bg-orange-500' },
+];
+const surfaceOptions = [
+    { label: 'Blue', value: 'blue', class: 'bg-blue-200' },
+    { label: 'Gray', value: 'gray', class: 'bg-gray-200' },
 ];
 </script>
 

--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -57,15 +57,20 @@ const { dark, topNav, primary, surface } = useSettings();
 const primaryOptions = [
     { label: 'Blue', value: 'blue', class: 'bg-blue-500' },
     { label: 'Purple', value: 'purple', class: 'bg-purple-500' },
+    { label: 'Indigo', value: 'indigo', class: 'bg-indigo-500' },
     { label: 'Teal', value: 'teal', class: 'bg-teal-500' },
     { label: 'Pink', value: 'pink', class: 'bg-pink-500' },
-    { label: 'Gray', value: 'gray', class: 'bg-gray-500' },
+    { label: 'Black', value: 'gray', class: 'bg-black' },
     { label: 'Green', value: 'green', class: 'bg-green-500' },
     { label: 'Orange', value: 'orange', class: 'bg-orange-500' },
 ];
 const surfaceOptions = [
     { label: 'Blue', value: 'blue', class: 'bg-blue-200' },
     { label: 'Gray', value: 'gray', class: 'bg-gray-200' },
+    { label: 'Purple', value: 'purple', class: 'bg-purple-200' },
+    { label: 'Pink', value: 'pink', class: 'bg-pink-200' },
+    { label: 'Slate', value: 'slate', class: 'bg-slate-200' },
+    { label: 'Zinc', value: 'zinc', class: 'bg-zinc-200' },
 ];
 </script>
 

--- a/playground/src/composables/useSettings.js
+++ b/playground/src/composables/useSettings.js
@@ -4,8 +4,8 @@ const dark = ref(localStorage.getItem('playground_dark') === 'true');
 const topNav = ref(localStorage.getItem('playground_top_nav') === 'true');
 const primary = ref(localStorage.getItem('playground_primary') || 'blue');
 const surface = ref(localStorage.getItem('playground_surface') || 'blue');
-const primaryThemes = ['blue', 'purple', 'teal', 'pink', 'gray', 'green', 'orange'];
-const surfaceThemes = ['blue', 'gray'];
+const primaryThemes = ['blue', 'purple', 'indigo', 'teal', 'pink', 'gray', 'green', 'orange'];
+const surfaceThemes = ['blue', 'gray', 'purple', 'pink', 'slate', 'zinc'];
 
 watch(
   dark,

--- a/playground/src/composables/useSettings.js
+++ b/playground/src/composables/useSettings.js
@@ -2,8 +2,10 @@ import { ref, watch } from 'vue';
 
 const dark = ref(localStorage.getItem('playground_dark') === 'true');
 const topNav = ref(localStorage.getItem('playground_top_nav') === 'true');
-const theme = ref(localStorage.getItem('playground_theme') || 'blue');
-const themes = ['blue', 'purple', 'teal', 'pink', 'gray', 'green', 'orange'];
+const primary = ref(localStorage.getItem('playground_primary') || 'blue');
+const surface = ref(localStorage.getItem('playground_surface') || 'blue');
+const primaryThemes = ['blue', 'purple', 'teal', 'pink', 'gray', 'green', 'orange'];
+const surfaceThemes = ['blue', 'gray'];
 
 watch(
   dark,
@@ -23,17 +25,29 @@ watch(
 );
 
 watch(
-  theme,
+  primary,
   (value) => {
-    localStorage.setItem('playground_theme', value);
+    localStorage.setItem('playground_primary', value);
     document.documentElement.classList.remove(
-      ...themes.map((t) => `theme-${t}`)
+      ...primaryThemes.map((t) => `theme-primary-${t}`)
     );
-    document.documentElement.classList.add(`theme-${value}`);
+    document.documentElement.classList.add(`theme-primary-${value}`);
+  },
+  { immediate: true }
+);
+
+watch(
+  surface,
+  (value) => {
+    localStorage.setItem('playground_surface', value);
+    document.documentElement.classList.remove(
+      ...surfaceThemes.map((t) => `theme-surface-${t}`)
+    );
+    document.documentElement.classList.add(`theme-surface-${value}`);
   },
   { immediate: true }
 );
 
 export function useSettings() {
-  return { dark, topNav, theme };
+  return { dark, topNav, primary, surface };
 }


### PR DESCRIPTION
## Summary
- separate primary and surface palettes in playground theme CSS
- allow choosing primary and surface colors with swatches in config drawer
- persist selections and apply via settings composable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68ab64b5c5d08325b022c55011531c13