### PR TITLE
feat(ui): improve file upload component

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -506,7 +506,7 @@ const submit = async () => {
 - `multiple` – allow selecting multiple files.
 - `clearable` – show a clear button to reset the selection.
 - `chooseLabel` – text for the choose button.
-- `size` – `'small' | 'large'`.
+- `size` – `'small' | 'large'` to match `InputText` heights (34 px and 42 px).
 - `invalid` – show the error style with a red border.
 
 ##### Events

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -479,6 +479,27 @@ const submit = async () => {
 
 Use `v-model` to bind the selected file or files. Submit them with `FormData` to upload to your server. When `multiple` is true, `modelValue` becomes an array and each file should be appended separately.
 
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const files = ref<File[]>([]);
+
+const submit = async () => {
+    const form = new FormData();
+    files.value.forEach((file, i) => form.append(`files[${i}]`, file));
+    await fetch('/upload', { method: 'POST', body: form });
+};
+</script>
+
+<template>
+  <form @submit.prevent="submit">
+    <FileUpload v-model="files" multiple clearable />
+    <button type="submit">Upload</button>
+  </form>
+</template>
+```
+
 ##### Props
 
 - `modelValue` – selected `File` or `File[]`.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -33,6 +33,7 @@ See the [App Layout](ui/application.md) for a ready-to-use application wrapper.
     - [Password](#password)
     - [Slider](#slider)
     - [Editor](#editor)
+    - [FileUpload](#fileupload)
   - [Layout](#layout)
     - [ScrollFrame](#scrollframe)
     - [Accordion](#accordion)
@@ -446,6 +447,50 @@ import { Editor } from '@atlas/ui';
 - `toolbarOptions` – array of toolbar buttons to display.
 - `textOnly` – restrict to plain text input.
 - `toolbarClass` – additional classes for the toolbar.
+
+#### FileUpload
+```ts
+import { FileUpload } from '@atlas/ui';
+```
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const file = ref<File | null>(null);
+
+const submit = async () => {
+    if (!file.value) return;
+
+    const form = new FormData();
+    form.append('file', file.value);
+
+    await fetch('/upload', { method: 'POST', body: form });
+};
+</script>
+
+<template>
+  <form @submit.prevent="submit">
+    <FileUpload v-model="file" clearable />
+    <button type="submit">Upload</button>
+  </form>
+</template>
+```
+
+Use `v-model` to bind the selected file or files. Submit them with `FormData` to upload to your server. When `multiple` is true, `modelValue` becomes an array and each file should be appended separately.
+
+##### Props
+
+- `modelValue` – selected `File` or `File[]`.
+- `multiple` – allow selecting multiple files.
+- `clearable` – show a clear button to reset the selection.
+- `chooseLabel` – text for the choose button.
+- `size` – `'small' | 'large'`.
+- `invalid` – show the error style with a red border.
+
+##### Events
+
+- `update:modelValue` – emitted with the selected file or files.
 
 ### Layout
 

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -5,7 +5,7 @@
                 baseClass,
                 paddingClass,
                 sizeClass,
-                invalidClass,
+                borderColorClass,
                 isDisabled
                     ? 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-400 opacity-70 shadow-none cursor-not-allowed'
                     : 'bg-surface-0 dark:bg-surface-950 text-surface-900 dark:text-surface-0 hover:border-surface-400 dark:hover:border-surface-600 cursor-pointer',
@@ -16,6 +16,7 @@
         >
             <Button
                 type="button"
+                outlined
                 :label="chooseLabel"
                 @click.stop="choose"
                 :disabled="isDisabled"
@@ -75,12 +76,14 @@ const rootClass = computed(() => (attrs as any).class);
 const rootStyle = computed(() => (attrs as any).style);
 
 const sizeClass = computed(() => (props.size ? `p-${props.size}` : ''));
-const invalidClass = computed(() => (props.invalid ? 'p-invalid' : ''));
+const borderColorClass = computed(() =>
+    props.invalid ? 'border-red-400 dark:border-red-500' : 'border-surface-300 dark:border-surface-700'
+);
 const paddingClass = computed(() =>
     props.size === 'small' ? 'px-px py-0' : 'px-1 py-0'
 );
 const baseClass =
-    'flex items-center rounded-md border border-surface-300 dark:border-surface-700 focus-within:border-primary p-invalid:border-red-400 dark:p-invalid:border-red-500 transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';
+    'flex items-center rounded-md border focus-within:border-primary transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';
 const buttonPaddingClass = computed(() => {
     switch (props.size) {
         case 'small':

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -3,6 +3,7 @@
         <div
             :class="[
                 baseClass,
+                heightClass,
                 paddingClass,
                 sizeClass,
                 borderColorClass,
@@ -77,7 +78,8 @@ const sizeClass = computed(() => (props.size ? `p-${props.size}` : ''));
 const borderColorClass = computed(() =>
     props.invalid ? 'border-red-400 dark:border-red-500' : 'border-surface-300 dark:border-surface-700'
 );
-const paddingClass = 'p-2';
+const heightClass = 'h-10 p-small:h-8 p-large:h-12';
+const paddingClass = 'px-3 p-small:px-[0.625rem] p-large:px-[0.875rem]';
 const baseClass =
     'flex items-center rounded-md border focus-within:border-primary transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';
 const inputAttrs = computed(() => {
@@ -112,11 +114,11 @@ const fileNames = computed(() => {
 });
 const hasFile = computed(() => !!fileNames.value);
 
-const textBase = `flex items-center w-full
+const textBase = `flex items-center w-full h-full
     bg-surface-0 dark:bg-surface-950
-    px-3 py-[9px] leading-[1.25rem] text-sm
-    p-small:text-xs p-small:px-[0.625rem] p-small:py-[0.375rem]
-    p-large:text-base p-large:px-[0.875rem] p-large:py-[0.625rem]
+    leading-[1.25rem] text-sm
+    p-small:text-xs
+    p-large:text-base
     transition-colors duration-200`;
 </script>
 

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -16,13 +16,11 @@
         >
             <Button
                 type="button"
-                outlined
                 :label="chooseLabel"
                 @click.stop="choose"
                 :disabled="isDisabled"
-                :size="props.size"
-                class="mr-2"
-                :class="buttonPaddingClass"
+                size="small"
+                class="mr-2 bg-black text-white border-black hover:bg-black/80 hover:border-black/80 !px-2 !py-1 text-xs"
             />
             <div class="relative flex-1">
                 <div :class="[textBase, clearable && hasFile ? 'pr-8' : '', isDisabled ? 'text-surface-700 dark:text-surface-400 bg-surface-200' : hasFile ? 'text-surface-900 dark:text-surface-0' : 'text-surface-500 dark:text-surface-400']">
@@ -79,21 +77,9 @@ const sizeClass = computed(() => (props.size ? `p-${props.size}` : ''));
 const borderColorClass = computed(() =>
     props.invalid ? 'border-red-400 dark:border-red-500' : 'border-surface-300 dark:border-surface-700'
 );
-const paddingClass = computed(() =>
-    props.size === 'small' ? 'px-px py-0' : 'px-1 py-0'
-);
+const paddingClass = 'p-2';
 const baseClass =
     'flex items-center rounded-md border focus-within:border-primary transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';
-const buttonPaddingClass = computed(() => {
-    switch (props.size) {
-        case 'small':
-            return '!py-1';
-        case 'large':
-            return '!py-2';
-        default:
-            return '!py-1.5';
-    }
-});
 const inputAttrs = computed(() => {
     const { class: _c, style: _s, ...rest } = attrs as any;
     return rest;

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -21,7 +21,9 @@
                 @click.stop="choose"
                 :disabled="isDisabled"
                 size="small"
-                class="mr-2 bg-black text-white border-black hover:bg-black/80 hover:border-black/80 !px-2 !py-1 text-xs"
+                rounded
+                outlined
+                class="mr-2"
             />
             <div class="relative flex-1">
                 <div :class="[textBase, clearable && hasFile ? 'pr-8' : '', isDisabled ? 'text-surface-700 dark:text-surface-400 bg-surface-200' : hasFile ? 'text-surface-900 dark:text-surface-0' : 'text-surface-500 dark:text-surface-400']">
@@ -78,7 +80,7 @@ const sizeClass = computed(() => (props.size ? `p-${props.size}` : ''));
 const borderColorClass = computed(() =>
     props.invalid ? 'border-red-400 dark:border-red-500' : 'border-surface-300 dark:border-surface-700'
 );
-const heightClass = 'h-10 p-small:h-8 p-large:h-12';
+const heightClass = 'h-10 p-small:h-[34px] p-large:h-[42px]';
 const paddingClass = 'px-3 p-small:px-[0.625rem] p-large:px-[0.875rem]';
 const baseClass =
     'flex items-center rounded-md border focus-within:border-primary transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';


### PR DESCRIPTION
## Summary
- refine FileUpload error styling and use outlined select button
- document FileUpload usage with server upload example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab656122b88325a7e9052e7355bcb8