### PR TITLE
Align switch and chips with primary color

### DIFF
--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -24,27 +24,27 @@
         <div>
           <span class="block mb-2 font-medium">Primary</span>
           <div class="flex gap-2">
-            <button
-              v-for="option in primaryOptions"
-              :key="option.value"
-              :class="['w-6 h-6 rounded-full border cursor-pointer', option.class, primary === option.value ? 'ring-2 ring-offset-2 ring-primary-500' : '']"
-              @click="primary = option.value"
-              :aria-label="option.label"
-              v-tooltip.bottom="{ value: option.label }"
-            ></button>
+              <button
+                v-for="option in primaryOptions"
+                :key="option.value"
+                :class="['w-6 h-6 rounded-full border cursor-pointer', option.class, primary === option.value ? 'ring-2 ring-offset-2 ring-primary-500' : 'hover:ring-2 hover:ring-offset-2 hover:ring-primary-500']"
+                @click="primary = option.value"
+                :aria-label="option.label"
+                v-tooltip.bottom="{ value: option.label }"
+              ></button>
           </div>
         </div>
         <div>
           <span class="block mb-2 font-medium">Surface</span>
           <div class="flex gap-2">
-            <button
-              v-for="option in surfaceOptions"
-              :key="option.value"
-              :class="['w-6 h-6 rounded-full border cursor-pointer', option.class, surface === option.value ? 'ring-2 ring-offset-2 ring-primary-500' : '']"
-              @click="surface = option.value"
-              :aria-label="option.label"
-              v-tooltip.bottom="{ value: option.label }"
-            ></button>
+              <button
+                v-for="option in surfaceOptions"
+                :key="option.value"
+                :class="['w-6 h-6 rounded-full border cursor-pointer', option.class, surface === option.value ? 'ring-2 ring-offset-2 ring-primary-500' : 'hover:ring-2 hover:ring-offset-2 hover:ring-primary-500']"
+                @click="surface = option.value"
+                :aria-label="option.label"
+                v-tooltip.bottom="{ value: option.label }"
+              ></button>
           </div>
         </div>
       </div>

--- a/ui/src/components/AutoComplete.vue
+++ b/ui/src/components/AutoComplete.vue
@@ -57,16 +57,16 @@ const theme = ref<AutoCompletePassThroughOptions>({
     chipItem: ``,
     pcChip: {
         root: `inline-flex items-center rounded-sm gap-2 px-3 py-1
-            bg-surface-100 dark:bg-surface-800
-            text-surface-800 dark:text-surface-0
+            bg-primary-500 dark:bg-primary-500
+            text-white dark:text-surface-0
             has-[img]:pt-1 has-[img]:pb-1
-            p-focus:bg-surface-200 p-focus:text-surface-800 dark:p-focus:bg-surface-700 dark:p-focus:text-surface-0
+            p-focus:bg-primary-500 p-focus:text-white dark:p-focus:bg-primary-500 dark:p-focus:text-surface-0
             p-removable:pe-2`,
         image: `rounded-full w-8 h-8 -ms-2`,
-        icon: `text-surface-800 dark:bg-surface-0 text-base w-4 h-4`,
+        icon: `text-white dark:text-surface-0 text-base w-4 h-4`,
         label: ``,
         removeIcon: `cursor-pointer text-base w-4 h-4 rounded-full
-            text-surface-800 dark:text-surface-0
+            text-white dark:text-surface-0
             focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary`
     },
     chipIcon: ``,
@@ -95,7 +95,7 @@ const theme = ref<AutoCompletePassThroughOptions>({
     option: `cursor-pointer font-normal whitespace-nowrap relative overflow-hidden flex items-center
     px-3 py-1.5 border-none text-surface-700 dark:text-surface-0 bg-transparent rounded-sm
     p-focus:bg-surface-100 dark:p-focus:bg-surface-800 p-focus:text-surface-800 dark:p-focus:text-surface-0
-    p-selected:bg-primary-400 p-focus:p-selected:bg-primary-400 p-selected:text-white p-focus:p-selected:text-white dark:p-selected:bg-primary-600 dark:p-focus:p-selected:bg-primary-600
+    p-selected:bg-primary-500 p-focus:p-selected:bg-primary-500 p-selected:text-white p-focus:p-selected:text-white dark:p-selected:bg-primary-500 dark:p-focus:p-selected:bg-primary-500
     transition-colors duration-200 text-sm`,
     emptyMessage: `px-3 py-2.5`,
     searchResultMessage: ``,

--- a/ui/src/components/Chip.vue
+++ b/ui/src/components/Chip.vue
@@ -7,7 +7,7 @@
     >
         <template #removeicon="{ removeCallback, keydownCallback }">
             <TimesCircleIcon
-                class="cursor-pointer text-base w-4 h-4 rounded-full text-surface-800 dark:text-surface-0 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-primary"
+                class="cursor-pointer text-base w-4 h-4 rounded-full text-white dark:text-surface-0 focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-primary"
                 @click="removeCallback"
                 @keydown="keydownCallback"
             />
@@ -30,12 +30,12 @@ const attrs = useAttrs();
 
 const theme = ref<ChipPassThroughOptions>({
     root: `inline-flex items-center rounded-2xl gap-2 px-3 py-2
-        bg-surface-100 dark:bg-surface-800
-        text-surface-800 dark:text-surface-0
+        bg-primary-500 dark:bg-primary-500
+        text-white dark:text-surface-0
         has-[img]:pt-1 has-[img]:pb-1
         p-removable:pe-2`,
     image: `rounded-full w-8 h-8 -ms-2`,
-    icon: `text-surface-800 dark:text-surface-0 text-base w-4 h-4`
+    icon: `text-white dark:text-surface-0 text-base w-4 h-4`
 });
 
 const mergedPt = computed(() => ptMerge(theme.value, props.pt));

--- a/ui/src/components/MultiSelect.vue
+++ b/ui/src/components/MultiSelect.vue
@@ -66,7 +66,7 @@ const theme = ref<MultiSelectPassThroughOptions>({
     chipItem: ``,
     pcChip: {
         root: `inline-flex items-center gap-2 px-3 py-[5px] rounded-sm
-            bg-primary-400 dark:bg-primary-600
+            bg-primary-500 dark:bg-primary-500
             text-white dark:text-surface-0
             has-[img]:pt-1 has-[img]:pb-1
             p-removable:pe-2`,

--- a/ui/src/components/ToggleSwitch.vue
+++ b/ui/src/components/ToggleSwitch.vue
@@ -28,7 +28,7 @@ const theme = ref<ToggleSwitchPassThroughOptions>({
         border border-transparent
         transition-colors duration-200
         peer-enabled:peer-hover:bg-surface-400 dark:peer-enabled:peer-hover:bg-surface-600
-        p-checked:bg-primary peer-enabled:peer-hover:p-checked:bg-primary-emphasis
+        p-checked:bg-primary-500 peer-enabled:peer-hover:p-checked:bg-primary-500/70 peer-enabled:peer-active:p-checked:bg-primary-500/60
         p-invalid:border-red-400 dark:p-invalid:border-red-300
         p-disabled:bg-surface-200 dark:p-disabled:bg-surface-600
         peer-focus-visible:outline peer-focus-visible:outline-1 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary`,
@@ -37,7 +37,7 @@ const theme = ref<ToggleSwitchPassThroughOptions>({
         text-surface-500 dark:text-surface-900
         w-4 h-4 start-1 -mt-2 rounded-full
         transition-[background,color,left] duration-200
-        p-checked:bg-surface-0 dark:p-checked:bg-surface-900 p-checked:text-primary p-checked:start-5
+        p-checked:bg-surface-0 dark:p-checked:bg-surface-900 p-checked:text-primary-500 p-checked:start-5
         p-disabled:bg-surface-700 dark:p-disabled:bg-surface-900`
 });
 


### PR DESCRIPTION
## Summary
- ensure ToggleSwitch and chip components use exact primary color
- match MultiSelect and AutoComplete chip styling to primary-500
- show primary ring on hover for theme selector options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab6d31e8cc83259b6e4186abed8afe