### PR TITLE
feat: add multi-file upload to playground form

### DIFF
--- a/playground/src/pages/components/forms/Index.vue
+++ b/playground/src/pages/components/forms/Index.vue
@@ -71,6 +71,11 @@
                   <FileUpload v-model="form.file" clearable />
                 </LabelField>
               </div>
+              <div class="w-full">
+                <LabelField name="files" label="Files">
+                  <FileUpload v-model="form.files" multiple clearable />
+                </LabelField>
+              </div>
             </div>
           </template>
         </Card>
@@ -135,6 +140,11 @@
               <div class="w-full">
                 <LabelField name="file" label="File">
                   <FileUpload v-model="form.file" clearable :disabled="true" />
+                </LabelField>
+              </div>
+              <div class="w-full">
+                <LabelField name="files" label="Files">
+                  <FileUpload v-model="form.files" multiple clearable :disabled="true" />
                 </LabelField>
               </div>
             </div>
@@ -278,6 +288,7 @@ const form = reactive({
     time: new Date('2024-01-01T12:00:00'),
     description: 'Example description',
     file: null,
+    files: [],
 });
 
 const roles = ref([

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -22,11 +22,11 @@
                 :disabled="isDisabled"
                 size="small"
                 rounded
-                class="mr-2"
+                class="mr-2 flex-shrink-0"
             />
-            <div class="relative flex-1">
+            <div class="relative flex-1 min-w-0">
                 <div :class="[textBase, clearable && hasFile ? 'pr-8' : '', isDisabled ? 'text-surface-700 dark:text-surface-400 bg-surface-200' : hasFile ? 'text-surface-900 dark:text-surface-0' : 'text-surface-500 dark:text-surface-400']">
-                    <span class="truncate">{{ fileNames || 'No file selected' }}</span>
+                    <span class="block truncate">{{ fileNames || 'No file selected' }}</span>
                 </div>
                 <button
                     v-if="clearable && hasFile"

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -22,7 +22,6 @@
                 :disabled="isDisabled"
                 size="small"
                 rounded
-                outlined
                 class="mr-2"
             />
             <div class="relative flex-1">

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -111,7 +111,10 @@ const model = computed(() => props.modelValue);
 const fileNames = computed(() => {
     const value = model.value;
     if (!value || (Array.isArray(value) && value.length === 0)) return '';
-    return Array.isArray(value) ? value.map((f) => f.name).join(', ') : value.name;
+    if (Array.isArray(value)) {
+        return value.length === 1 ? value[0].name : `${value.length} files selected`;
+    }
+    return value.name;
 });
 const hasFile = computed(() => !!fileNames.value);
 

--- a/ui/tests/components/FileUpload.test.ts
+++ b/ui/tests/components/FileUpload.test.ts
@@ -51,4 +51,21 @@ describe('FileUpload', () => {
         const label = wrapper.find('span.truncate');
         expect(label.text()).toBe('2 files selected');
     });
+
+    it('truncates long file names without shrinking choose button', () => {
+        const longName = 'a'.repeat(300) + '.txt';
+        const file = new File(['a'], longName, { type: 'text/plain' });
+        const wrapper = mount(FileUpload, {
+            props: { clearable: true, modelValue: file },
+            global: { plugins: [PrimeVue] },
+        });
+        const buttons = wrapper.findAll('button');
+        expect(buttons[0].classes()).toContain('flex-shrink-0');
+        const labelWrapper = wrapper.find('.relative.flex-1');
+        expect(labelWrapper.classes()).toContain('min-w-0');
+        const textDiv = labelWrapper.find('div');
+        expect(textDiv.classes()).toContain('pr-8');
+        const label = wrapper.find('span.truncate');
+        expect(label.text()).toBe(longName);
+    });
 });

--- a/ui/tests/components/FileUpload.test.ts
+++ b/ui/tests/components/FileUpload.test.ts
@@ -30,4 +30,25 @@ describe('FileUpload', () => {
         const button = wrapper.find('button');
         expect(button.text()).toBe('Select');
     });
+
+    it('shows file name when one file selected', () => {
+        const file = new File(['a'], 'a.txt', { type: 'text/plain' });
+        const wrapper = mount(FileUpload, {
+            props: { multiple: true, modelValue: [file] },
+            global: { plugins: [PrimeVue] },
+        });
+        const label = wrapper.find('span.truncate');
+        expect(label.text()).toBe('a.txt');
+    });
+
+    it('shows file count when multiple files selected', () => {
+        const file1 = new File(['a'], 'a.txt', { type: 'text/plain' });
+        const file2 = new File(['b'], 'b.txt', { type: 'text/plain' });
+        const wrapper = mount(FileUpload, {
+            props: { multiple: true, modelValue: [file1, file2] },
+            global: { plugins: [PrimeVue] },
+        });
+        const label = wrapper.find('span.truncate');
+        expect(label.text()).toBe('2 files selected');
+    });
 });


### PR DESCRIPTION
## Summary
- support selecting multiple files in playground form
- render FileUpload choose button with solid styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ab6d692d8c8325912607f26ce25c38