### PR TITLE
fix: raise tooltip z-index and centralize styling

### DIFF
--- a/playground/src/main.js
+++ b/playground/src/main.js
@@ -12,7 +12,7 @@ import './style.css';
 const app = createApp(App);
 app.use(router);
 app.use(ToastService);
-app.use(PrimeVue, { unstyled: true });
+app.use(PrimeVue, { unstyled: true, zIndex: { tooltip: 2100 } });
 app.directive('tooltip', Tooltip);
 app.directive('styleclass', StyleClass);
 app.mount('#app');

--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -34,12 +34,12 @@
                                 :is="linkComponent"
                                 v-tooltip.right="{
                                     value: child.label,
-                                        pt: {
-                                            root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] ml-3',
-                                            text: autoDark
-                                                ? 'text-sm p-2 border border-surface-300 bg-white text-surface-700 dark:bg-surface-700 dark:border-surface-800 dark:text-white rounded whitespace-pre-line'
-                                                : 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-                                        }
+                                    pt: {
+                                        root: 'ml-3',
+                                        text: autoDark
+                                            ? 'border-surface-300 bg-white text-surface-700 dark:bg-surface-700 dark:border-surface-800 dark:text-white'
+                                            : undefined
+                                    }
                                 }"
                                 class="relative flex items-center justify-center w-full h-12 mt-2 rounded"
                                 :href="child.href"

--- a/ui/src/components/App/Page/SideNav.vue
+++ b/ui/src/components/App/Page/SideNav.vue
@@ -93,8 +93,7 @@ const props = withDefaults(defineProps<Props>(), {
 const { items, linkComponent } = props;
 
 const tooltipPt = {
-    root: 'absolute ml-2 shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-    text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+    root: 'ml-2'
 };
 
 const isActive = (item: NavItem) =>

--- a/ui/src/components/App/Table/Actions.vue
+++ b/ui/src/components/App/Table/Actions.vue
@@ -8,13 +8,7 @@
             <div
                 v-for="(menuItem, index) in menuItems"
                 :key="index"
-                v-tooltip.bottom="{
-                    value: menuItem?.tooltip ?? null,
-                    pt: {
-                        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] mt-1',
-                        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-                    }
-                }"
+                v-tooltip.bottom="{ value: menuItem?.tooltip ?? null, pt: { root: 'mt-1' } }"
                 class="pl-3"
             >
                 <div v-if="menuItem.children && menuItem.children.length" class="relative">
@@ -70,13 +64,7 @@
             </div>
             <div>
                 <button
-                    v-tooltip.bottom="{
-                        value: 'Clear selection',
-                        pt: {
-                            root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] mt-1',
-                            text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-                        }
-                    }"
+                    v-tooltip.bottom="{ value: 'Clear selection', pt: { root: 'mt-1' } }"
                     type="button"
                     class="flex items-center justify-center hover:bg-primary-600/50 transition px-3 py-2 cursor-pointer opacity-80 hover:opacity-100"
                     @click="$emit('action', 'clear')"

--- a/ui/src/components/App/Table/Table.vue
+++ b/ui/src/components/App/Table/Table.vue
@@ -9,13 +9,7 @@
             >
                 <template #trigger="{ toggle }">
                     <div
-                        v-tooltip.left="{
-                            value: 'Customize columns',
-                            pt: {
-                                root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-                                text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-                            }
-                        }"
+                        v-tooltip.left="{ value: 'Customize columns' }"
                         class="bg-white border border-gray-300 cursor-pointer text-surface-600 dark:text-surface-400 hover:text-surface-800 dark:hover:text-surface-300 h-[38px] w-[38px] flex items-center justify-center rounded-bl-lg rounded-br-lg"
                         @click="toggle"
                     >

--- a/ui/src/components/Editor/Tools/BoldTool.vue
+++ b/ui/src/components/Editor/Tools/BoldTool.vue
@@ -26,10 +26,6 @@ const props = defineProps({
 });
 
 const tooltip = {
-    value: 'Bold',
-    pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-    }
+    value: 'Bold'
 };
 </script>

--- a/ui/src/components/Editor/Tools/BulletListTool.vue
+++ b/ui/src/components/Editor/Tools/BulletListTool.vue
@@ -24,10 +24,6 @@ import Button from '../../Button.vue';
 const props = defineProps({ editor: Object });
 
 const tooltip = {
-    value: 'Bullet list',
-    pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-    }
+    value: 'Bullet list'
 };
 </script>

--- a/ui/src/components/Editor/Tools/ClearFormattingTool.vue
+++ b/ui/src/components/Editor/Tools/ClearFormattingTool.vue
@@ -20,10 +20,6 @@ import Button from '../../Button.vue';
 const props = defineProps({ editor: Object });
 
 const tooltip = {
-    value: 'Clear formatting',
-    pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-    }
+    value: 'Clear formatting'
 };
 </script>

--- a/ui/src/components/Editor/Tools/ItalicTool.vue
+++ b/ui/src/components/Editor/Tools/ItalicTool.vue
@@ -24,10 +24,6 @@ import Button from '../../Button.vue';
 const props = defineProps({ editor: Object });
 
 const tooltip = {
-    value: 'Italic',
-    pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-    }
+    value: 'Italic'
 };
 </script>

--- a/ui/src/components/Editor/Tools/LinkTool.vue
+++ b/ui/src/components/Editor/Tools/LinkTool.vue
@@ -76,10 +76,6 @@ const toggleLinkPopover = (event) => {
 };
 
 const tooltip = {
-    value: 'Add link',
-    pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-    }
+    value: 'Add link'
 };
 </script>

--- a/ui/src/components/Editor/Tools/OrderedListTool.vue
+++ b/ui/src/components/Editor/Tools/OrderedListTool.vue
@@ -24,10 +24,6 @@ import Button from '../../Button.vue';
 const props = defineProps({ editor: Object });
 
 const tooltip = {
-    value: 'Numbered list',
-    pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-    }
+    value: 'Numbered list'
 };
 </script>

--- a/ui/src/components/Editor/Tools/StrikeTool.vue
+++ b/ui/src/components/Editor/Tools/StrikeTool.vue
@@ -24,10 +24,6 @@ import Button from '../../Button.vue';
 const props = defineProps({ editor: Object });
 
 const tooltip = {
-    value: 'Strikethrough',
-    pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-    }
+    value: 'Strikethrough'
 };
 </script>

--- a/ui/src/components/TooltipIcon.vue
+++ b/ui/src/components/TooltipIcon.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
 import { IconInfoSquareRoundedFilled } from '@tabler/icons-vue';
-import { ref, computed } from 'vue';
+import { computed } from 'vue';
 import { ptMerge } from '../utils';
 
 interface TooltipDirectivePassThroughOptions {
@@ -38,13 +38,8 @@ const theme = computed<TooltipIconPassThroughOptions>(() => ({
 
 const mergedPt = computed(() => ptMerge(theme.value, props.pt));
 
-const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
-    root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-    text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
-});
-
 const tooltip = computed(() => ({
     value: props.text,
-    pt: ptMerge(tooltipTheme.value, props.pt?.tooltip)
+    pt: props.pt?.tooltip
 }));
 </script>

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -1,3 +1,4 @@
+import 'primevue/tooltip/style';
 import './style.css';
 
 export * from './components';

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -1,10 +1,6 @@
 
 /* Global tooltip styling */
 .p-tooltip {
-  position: absolute;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-  padding: 0;
-  max-width: 260px;
   z-index: 2100 !important;
   animation: atlas-tooltip-drop 100ms cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -12,9 +8,11 @@
 .p-tooltip .p-tooltip-text {
   font-size: 0.875rem;
   padding: 0.5rem;
+  max-width: 260px;
   border: 1px solid var(--p-surface-700);
   background-color: var(--p-surface-900);
   color: #ffffff;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   border-radius: 0.25rem;
   white-space: pre-line;
 }

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -1,5 +1,13 @@
-.atlas-tooltip {
+
+/* Global tooltip styling */
+.p-tooltip {
+  @apply absolute shadow-md py-0 px-0 max-w-[260px];
+  z-index: 2100 !important;
   animation: atlas-tooltip-drop 100ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.p-tooltip .p-tooltip-text {
+  @apply text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line;
 }
 
 @keyframes atlas-tooltip-drop {

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -1,13 +1,27 @@
 
 /* Global tooltip styling */
 .p-tooltip {
-  @apply absolute shadow-md py-0 px-0 max-w-[260px];
+  position: absolute;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  padding: 0;
+  max-width: 260px;
   z-index: 2100 !important;
   animation: atlas-tooltip-drop 100ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .p-tooltip .p-tooltip-text {
-  @apply text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line;
+  font-size: 0.875rem;
+  padding: 0.5rem;
+  border: 1px solid var(--p-surface-700);
+  background-color: var(--p-surface-900);
+  color: #ffffff;
+  border-radius: 0.25rem;
+  white-space: pre-line;
+}
+
+.dark .p-tooltip .p-tooltip-text {
+  background-color: var(--p-surface-700);
+  border-color: var(--p-surface-800);
 }
 
 @keyframes atlas-tooltip-drop {


### PR DESCRIPTION
## Summary
- raise PrimeVue tooltip z-index to `2100`
- consolidate tooltip classes into global CSS so components no longer need per-instance styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab6decaf1c8325a9f94f37446636cd