### PR TITLE
feat(theme): add rounding tokens

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -104,6 +104,7 @@ Atlas exposes rounding tokens for consistent border radius:
 | `--p-rounded-1` | `0.25rem` |
 | `--p-rounded-2` | `0.5rem` |
 | `--p-rounded-3` | `0.75rem` |
+| `--p-rounded-4` | `1rem` |
 
 Use them with Tailwind's arbitrary values, for example:
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -6,6 +6,7 @@ See the [App Layout](ui/application.md) for a ready-to-use application wrapper.
 
 ## Table of Contents
 - [Setup](#setup)
+- [Theme Options](#theme-options)
 - [Override Themes with Passthrough](#override-themes-with-passthrough)
 - [Components](#components)
   - [Application](ui/application.md)
@@ -90,6 +91,26 @@ export default defineConfig({
 ```
 
 If you're using another bundler, configure an equivalent alias so `@atlas/ui` points to the package.
+
+## Theme Options
+
+### Rounding
+
+Atlas exposes rounding tokens for consistent border radius:
+
+| Token | Value |
+| ----- | ----- |
+| `--p-rounded-0` | `0rem` |
+| `--p-rounded-1` | `0.25rem` |
+| `--p-rounded-2` | `0.5rem` |
+| `--p-rounded-3` | `0.75rem` |
+| `--p-rounded-4` | `1rem` |
+
+Use them with Tailwind's arbitrary values, for example:
+
+```html
+<div class="rounded-[var(--p-rounded-2)]"></div>
+```
 
 ## Override Themes with Passthrough
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -104,7 +104,6 @@ Atlas exposes rounding tokens for consistent border radius:
 | `--p-rounded-1` | `0.25rem` |
 | `--p-rounded-2` | `0.5rem` |
 | `--p-rounded-3` | `0.75rem` |
-| `--p-rounded-4` | `1rem` |
 
 Use them with Tailwind's arbitrary values, for example:
 

--- a/playground/src/base.css
+++ b/playground/src/base.css
@@ -214,6 +214,26 @@
     --p-content-border-radius: var(--p-rounded-1);
 }
 
+.theme-rounded-0 {
+    --p-content-border-radius: var(--p-rounded-0);
+}
+
+.theme-rounded-1 {
+    --p-content-border-radius: var(--p-rounded-1);
+}
+
+.theme-rounded-2 {
+    --p-content-border-radius: var(--p-rounded-2);
+}
+
+.theme-rounded-3 {
+    --p-content-border-radius: var(--p-rounded-3);
+}
+
+.theme-rounded-4 {
+    --p-content-border-radius: var(--p-rounded-4);
+}
+
 /* Light */
 :root {
     --p-primary-color: var(--p-primary-500);

--- a/playground/src/base.css
+++ b/playground/src/base.css
@@ -127,8 +127,6 @@
     --p-surface-800: #1e293b;
     --p-surface-900: #0f172a;
     --p-surface-950: #020617;
-
-    --p-content-border-radius: 6px;
 }
 
 .theme-surface-gray {
@@ -204,6 +202,16 @@
     --p-surface-800: #27272a;
     --p-surface-900: #18181b;
     --p-surface-950: #09090b;
+}
+
+/* Rounding */
+:root {
+    --p-rounded-0: 0rem;
+    --p-rounded-1: 0.25rem;
+    --p-rounded-2: 0.5rem;
+    --p-rounded-3: 0.75rem;
+    --p-rounded-4: 1rem;
+    --p-content-border-radius: var(--p-rounded-1);
 }
 
 /* Light */

--- a/playground/src/base.css
+++ b/playground/src/base.css
@@ -210,6 +210,7 @@
     --p-rounded-1: 0.25rem;
     --p-rounded-2: 0.5rem;
     --p-rounded-3: 0.75rem;
+    --p-rounded-4: 1rem;
     --p-content-border-radius: var(--p-rounded-1);
 }
 
@@ -227,6 +228,10 @@
 
 .theme-rounded-3 {
     --p-content-border-radius: var(--p-rounded-3);
+}
+
+.theme-rounded-4 {
+    --p-content-border-radius: var(--p-rounded-4);
 }
 
 /* Light */

--- a/playground/src/base.css
+++ b/playground/src/base.css
@@ -210,7 +210,6 @@
     --p-rounded-1: 0.25rem;
     --p-rounded-2: 0.5rem;
     --p-rounded-3: 0.75rem;
-    --p-rounded-4: 1rem;
     --p-content-border-radius: var(--p-rounded-1);
 }
 
@@ -228,10 +227,6 @@
 
 .theme-rounded-3 {
     --p-content-border-radius: var(--p-rounded-3);
-}
-
-.theme-rounded-4 {
-    --p-content-border-radius: var(--p-rounded-4);
 }
 
 /* Light */

--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -96,7 +96,6 @@ const roundedOptions = [
     { label: '0.25', value: '1', class: 'rounded-[var(--p-rounded-1)]' },
     { label: '0.50', value: '2', class: 'rounded-[var(--p-rounded-2)]' },
     { label: '0.75', value: '3', class: 'rounded-[var(--p-rounded-3)]' },
-    { label: '1', value: '4', class: 'rounded-[var(--p-rounded-4)]' },
 ];
 </script>
 

--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -96,6 +96,7 @@ const roundedOptions = [
     { label: '0.25', value: '1', class: 'rounded-[var(--p-rounded-1)]' },
     { label: '0.50', value: '2', class: 'rounded-[var(--p-rounded-2)]' },
     { label: '0.75', value: '3', class: 'rounded-[var(--p-rounded-3)]' },
+    { label: '1', value: '4', class: 'rounded-[var(--p-rounded-4)]' },
 ];
 </script>
 

--- a/playground/src/components/ConfigDrawer.vue
+++ b/playground/src/components/ConfigDrawer.vue
@@ -47,6 +47,19 @@
               ></button>
           </div>
         </div>
+        <div>
+          <span class="block mb-2 font-medium">Rounding</span>
+          <div class="flex gap-2">
+              <button
+                v-for="option in roundedOptions"
+                :key="option.value"
+                :class="['w-6 h-6 border cursor-pointer bg-surface-0 dark:bg-surface-900', option.class, rounded === option.value ? 'ring-2 ring-offset-2 ring-primary-500' : 'hover:ring-2 hover:ring-offset-2 hover:ring-primary-500']"
+                @click="rounded = option.value"
+                :aria-label="option.label"
+                v-tooltip.bottom="{ value: option.label }"
+              ></button>
+          </div>
+        </div>
       </div>
     </UiDrawer>
   </div>
@@ -59,7 +72,7 @@ import ToggleSwitch from '@atlas/ui/components/ToggleSwitch.vue';
 import { useSettings } from '../composables/useSettings';
 
 const visible = ref(false);
-const { dark, topNav, primary, surface } = useSettings();
+const { dark, topNav, primary, surface, rounded } = useSettings();
 const primaryOptions = [
     { label: 'Blue', value: 'blue', class: 'bg-blue-500' },
     { label: 'Purple', value: 'purple', class: 'bg-purple-500' },
@@ -77,6 +90,13 @@ const surfaceOptions = [
     { label: 'Pink', value: 'pink', class: 'bg-pink-50 dark:bg-pink-900' },
     { label: 'Slate', value: 'slate', class: 'bg-slate-50 dark:bg-slate-900' },
     { label: 'Zinc', value: 'zinc', class: 'bg-zinc-50 dark:bg-zinc-900' },
+];
+const roundedOptions = [
+    { label: '0', value: '0', class: 'rounded-[var(--p-rounded-0)]' },
+    { label: '0.25', value: '1', class: 'rounded-[var(--p-rounded-1)]' },
+    { label: '0.50', value: '2', class: 'rounded-[var(--p-rounded-2)]' },
+    { label: '0.75', value: '3', class: 'rounded-[var(--p-rounded-3)]' },
+    { label: '1', value: '4', class: 'rounded-[var(--p-rounded-4)]' },
 ];
 </script>
 

--- a/playground/src/composables/useSettings.js
+++ b/playground/src/composables/useSettings.js
@@ -4,8 +4,10 @@ const dark = ref(localStorage.getItem('playground_dark') === 'true');
 const topNav = ref(localStorage.getItem('playground_top_nav') === 'true');
 const primary = ref(localStorage.getItem('playground_primary') || 'blue');
 const surface = ref(localStorage.getItem('playground_surface') || 'blue');
+const rounded = ref(localStorage.getItem('playground_rounded') || '1');
 const primaryThemes = ['blue', 'purple', 'indigo', 'teal', 'pink', 'gray', 'green', 'orange'];
 const surfaceThemes = ['blue', 'gray', 'purple', 'pink', 'slate', 'zinc'];
+const roundedOptions = ['0', '1', '2', '3', '4'];
 
 watch(
   dark,
@@ -48,6 +50,18 @@ watch(
   { immediate: true }
 );
 
+watch(
+  rounded,
+  (value) => {
+    localStorage.setItem('playground_rounded', value);
+    document.documentElement.classList.remove(
+      ...roundedOptions.map((r) => `theme-rounded-${r}`)
+    );
+    document.documentElement.classList.add(`theme-rounded-${value}`);
+  },
+  { immediate: true }
+);
+
 export function useSettings() {
-  return { dark, topNav, primary, surface };
+  return { dark, topNav, primary, surface, rounded };
 }

--- a/playground/src/composables/useSettings.js
+++ b/playground/src/composables/useSettings.js
@@ -7,7 +7,7 @@ const surface = ref(localStorage.getItem('playground_surface') || 'blue');
 const rounded = ref(localStorage.getItem('playground_rounded') || '1');
 const primaryThemes = ['blue', 'purple', 'indigo', 'teal', 'pink', 'gray', 'green', 'orange'];
 const surfaceThemes = ['blue', 'gray', 'purple', 'pink', 'slate', 'zinc'];
-const roundedOptions = ['0', '1', '2', '3', '4'];
+const roundedOptions = ['0', '1', '2', '3'];
 
 watch(
   dark,

--- a/playground/src/composables/useSettings.js
+++ b/playground/src/composables/useSettings.js
@@ -7,7 +7,7 @@ const surface = ref(localStorage.getItem('playground_surface') || 'blue');
 const rounded = ref(localStorage.getItem('playground_rounded') || '1');
 const primaryThemes = ['blue', 'purple', 'indigo', 'teal', 'pink', 'gray', 'green', 'orange'];
 const surfaceThemes = ['blue', 'gray', 'purple', 'pink', 'slate', 'zinc'];
-const roundedOptions = ['0', '1', '2', '3'];
+const roundedOptions = ['0', '1', '2', '3', '4'];
 
 watch(
   dark,

--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -22,7 +22,7 @@ const attrs = useAttrs();
 
 const theme = ref<ButtonPassThroughOptions>({
     root: `inline-flex align-middle cursor-pointer select-none items-center justify-center overflow-hidden relative
-        px-4 py-[9px] leading-5 gap-2 rounded disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
+        px-4 py-[9px] leading-5 gap-2 rounded-[var(--p-rounded-1)] disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
         bg-primary-500 enabled:hover:bg-primary-500/70 enabled:active:bg-primary-500/60 text-white text-md font-semibold p-text:!font-medium
         border border-primary-500 enabled:hover:border-primary-500/70 enabled:active:border-primary-500/60
         focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
@@ -33,7 +33,7 @@ const theme = ref<ButtonPassThroughOptions>({
         p-large:p-icon-only:w-[42px] p-large:p-icon-only:h-[42px] p-large:p-icon-only:p-0
         p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
         p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
-        p-raised:shadow-sm p-rounded:rounded-[2rem]
+        p-raised:shadow-sm p-rounded:rounded-[var(--p-rounded-4)]
         p-outlined:bg-transparent enabled:hover:p-outlined:bg-primary-50 enabled:active:p-outlined:bg-primary-100
         p-outlined:border-primary-200 enabled:hover:p-outlined:border-primary-200 enabled:active:p-outlined:border-primary-200
         p-outlined:text-primary enabled:hover:p-outlined:text-primary enabled:active:p-outlined:text-primary

--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -22,7 +22,7 @@ const attrs = useAttrs();
 
 const theme = ref<ButtonPassThroughOptions>({
     root: `inline-flex align-middle cursor-pointer select-none items-center justify-center overflow-hidden relative
-        px-4 py-[9px] leading-5 gap-2 rounded-[var(--p-rounded-1)] disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
+        px-4 py-[9px] leading-5 gap-2 rounded-[var(--p-content-border-radius)] disabled:pointer-events-none disabled:opacity-60 transition-colors duration-200
         bg-primary-500 enabled:hover:bg-primary-500/70 enabled:active:bg-primary-500/60 text-white text-md font-semibold p-text:!font-medium
         border border-primary-500 enabled:hover:border-primary-500/70 enabled:active:border-primary-500/60
         focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
@@ -33,7 +33,7 @@ const theme = ref<ButtonPassThroughOptions>({
         p-large:p-icon-only:w-[42px] p-large:p-icon-only:h-[42px] p-large:p-icon-only:p-0
         p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
         p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
-        p-raised:shadow-sm p-rounded:rounded-[var(--p-rounded-4)]
+        p-raised:shadow-sm p-rounded:rounded-[var(--p-rounded-3)]
         p-outlined:bg-transparent enabled:hover:p-outlined:bg-primary-50 enabled:active:p-outlined:bg-primary-100
         p-outlined:border-primary-200 enabled:hover:p-outlined:border-primary-200 enabled:active:p-outlined:border-primary-200
         p-outlined:text-primary enabled:hover:p-outlined:text-primary enabled:active:p-outlined:text-primary

--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -33,7 +33,7 @@ const theme = ref<ButtonPassThroughOptions>({
         p-large:p-icon-only:w-[42px] p-large:p-icon-only:h-[42px] p-large:p-icon-only:p-0
         p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
         p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
-        p-raised:shadow-sm p-rounded:rounded-[var(--p-rounded-3)]
+        p-raised:shadow-sm p-rounded:rounded-[var(--p-rounded-4)]
         p-outlined:bg-transparent enabled:hover:p-outlined:bg-primary-50 enabled:active:p-outlined:bg-primary-100
         p-outlined:border-primary-200 enabled:hover:p-outlined:border-primary-200 enabled:active:p-outlined:border-primary-200
         p-outlined:text-primary enabled:hover:p-outlined:text-primary enabled:active:p-outlined:text-primary

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -1,3 +1,14 @@
+/* Design Tokens */
+:root {
+  /* Rounding */
+  --p-rounded-0: 0rem;
+  --p-rounded-1: 0.25rem;
+  --p-rounded-2: 0.5rem;
+  --p-rounded-3: 0.75rem;
+  --p-rounded-4: 1rem;
+  --p-content-border-radius: var(--p-rounded-1);
+}
+
 .atlas-tooltip {
   animation: atlas-tooltip-drop 100ms cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -5,7 +5,6 @@
   --p-rounded-1: 0.25rem;
   --p-rounded-2: 0.5rem;
   --p-rounded-3: 0.75rem;
-  --p-rounded-4: 1rem;
   --p-content-border-radius: var(--p-rounded-1);
 }
 

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -5,6 +5,7 @@
   --p-rounded-1: 0.25rem;
   --p-rounded-2: 0.5rem;
   --p-rounded-3: 0.75rem;
+  --p-rounded-4: 1rem;
   --p-content-border-radius: var(--p-rounded-1);
 }
 


### PR DESCRIPTION
## Summary
- add global rounding tokens to theme
- document new rounding options
- update Button component to use rounding variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab6f0a8cbc832587cfe73e2596742e