### PR TITLE
Raise tooltip z-index to avoid overlay clashes

### DIFF
--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -1,5 +1,6 @@
 .atlas-tooltip {
   animation: atlas-tooltip-drop 100ms cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 2100 !important;
 }
 
 @keyframes atlas-tooltip-drop {


### PR DESCRIPTION
## Summary
- elevate tooltip z-index to 2100 to ensure overlays display above other elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab72958b188325b46d6d924fd0054a