### PR TITLE
Align form inputs with theme rounding

### DIFF
--- a/ui/src/components/DatePicker.vue
+++ b/ui/src/components/DatePicker.vue
@@ -111,7 +111,7 @@ const attrs = useAttrs();
 const theme = ref<DatePickerPassThroughOptions>({
     root: `inline-flex max-w-full relative p-fluid:flex`,
     pcInputText: {
-        root: `flex-auto w-[1%] appearance-none rounded-md outline-hidden
+        root: `flex-auto w-[1%] appearance-none rounded-[var(--p-content-border-radius)] outline-hidden
         p-has-dropdown:rounded-e-none p-has-e-icon:pe-10
         bg-surface-0 dark:bg-surface-950
         p-filled:bg-surface-50 dark:p-filled:bg-surface-800
@@ -129,7 +129,7 @@ const theme = ref<DatePickerPassThroughOptions>({
         p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]
         transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`
     },
-    dropdown: `cursor-pointer inline-flex items-center justify-center select-none overflow-hidden relative w-10 shrink-0 rounded-e-md
+    dropdown: `cursor-pointer inline-flex items-center justify-center select-none overflow-hidden relative w-10 shrink-0 rounded-e-[var(--p-content-border-radius)]
         border border-s-0 border-surface-300 dark:border-surface-700
         bg-surface-100 enabled:hover:bg-surface-200 enabled:active:bg-surface-300
         text-surface-600 enabled:hover:text-surface-700 enabled:hover:active:text-surface-800
@@ -138,7 +138,7 @@ const theme = ref<DatePickerPassThroughOptions>({
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
         transition-colors duration-200`,
     inputIconContainer: `cursor-pointer absolute top-1/2 end-3 -mt-2 text-surface-400 leading-none p-small:*:size-[0.875rem] p-large:*:size-[1.125rem]`,
-    panel: `p-portal-self:min-w-full w-auto p-3 rounded-md
+    panel: `p-portal-self:min-w-full w-auto p-3 rounded-[var(--p-content-border-radius)]
         p-inline:inline-block p-inline:overflow-x-auto p-inline:shadow-none
         border border-surface-200 dark:border-surface-700
         bg-surface-0 dark:bg-surface-900
@@ -153,12 +153,12 @@ const theme = ref<DatePickerPassThroughOptions>({
         border-b border-surface-200 dark:border-surface-700`,
     title: `flex items-center justify-between gap-2 font-medium`,
     selectMonth: `border-none bg-transparent m-0 cursor-pointer font-medium transition-colors duration-200
-        py-1 px-2 rounded-md text-surface-700 dark:text-surface-0
+        py-1 px-2 rounded-[var(--p-content-border-radius)] text-surface-700 dark:text-surface-0
         enabled:hover:bg-surface-100 enabled:hover:text-surface-800
         dark:enabled:hover:bg-surface-800 dark:enabled:hover:text-surface-0
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary`,
     selectYear: `border-none bg-transparent m-0 cursor-pointer font-medium transition-colors duration-200
-        py-1 px-2 rounded-md text-surface-700 dark:text-surface-0
+        py-1 px-2 rounded-[var(--p-content-border-radius)] text-surface-700 dark:text-surface-0
         enabled:hover:bg-surface-100 enabled:hover:text-surface-800
         dark:enabled:hover:bg-surface-800 dark:enabled:hover:text-surface-0
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary`,
@@ -187,13 +187,13 @@ const theme = ref<DatePickerPassThroughOptions>({
         p-today:p-selected:bg-primary p-today:p-selected:text-primary-contrast`,
     monthView: `mt-2 mb-0 mx-0`,
     month: `w-1/3 inline-flex items-center justify-center cursor-pointer overflow-hidden relative
-        p-[0.375rem] transition-colors duration-200 rounded-md text-surface-700 dark:text-surface-0
+        p-[0.375rem] transition-colors duration-200 rounded-[var(--p-content-border-radius)] text-surface-700 dark:text-surface-0
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
         hover:bg-surface-100 hover:text-surface-800 dark:hover:bg-surface-800 dark:hover:text-surface-0
         p-selected:bg-primary p-selected:text-primary-contrast`,
     yearView: `mt-2 mb-0 mx-0`,
     year: `w-1/2 inline-flex items-center justify-center cursor-pointer overflow-hidden relative
-        p-[0.375rem] transition-colors duration-200 rounded-md text-surface-700 dark:text-surface-0
+        p-[0.375rem] transition-colors duration-200 rounded-[var(--p-content-border-radius)] text-surface-700 dark:text-surface-0
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
         hover:bg-surface-100 hover:text-surface-800 dark:hover:bg-surface-800 dark:hover:text-surface-0
         p-selected:bg-primary p-selected:text-primary-contrast`,

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -82,7 +82,7 @@ const heightClass = 'h-10 p-small:h-[34px] p-large:h-[42px]';
 const paddingClass =
     'pl-[3px] pr-3 p-small:pl-0 p-small:pr-[0.625rem] p-large:pl-1 p-large:pr-[0.875rem]';
 const baseClass =
-    'flex items-center border focus-within:border-primary rounded-md transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';
+    'flex items-center border focus-within:border-primary rounded-[var(--p-content-border-radius)] transition-colors duration-200 overflow-hidden shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]';
 const inputAttrs = computed(() => {
     const { class: _c, style: _s, ...rest } = attrs as any;
     return rest;

--- a/ui/src/components/InputText.vue
+++ b/ui/src/components/InputText.vue
@@ -47,7 +47,7 @@ const clearInput = () => {
 const attrs = useAttrs();
 
 const theme = ref<InputTextPassThroughOptions>({
-    root: `appearance-none rounded-md outline-hidden
+    root: `appearance-none rounded-[var(--p-content-border-radius)] outline-hidden
         bg-surface-0 dark:bg-surface-950
         p-filled:bg-surface-50 dark:p-filled:bg-surface-800
         text-surface-900 dark:text-surface-0

--- a/ui/src/components/MultiSelect.vue
+++ b/ui/src/components/MultiSelect.vue
@@ -45,7 +45,7 @@ interface Props extends /* @vue-ignore */ MultiSelectProps {}
 const props = defineProps<Props>();
 
 const theme = ref<MultiSelectPassThroughOptions>({
-    root: `inline-flex cursor-pointer relative select-none rounded-md p-fluid:flex
+    root: `inline-flex cursor-pointer relative select-none rounded-[var(--p-content-border-radius)] p-fluid:flex
         bg-surface-0 dark:bg-surface-950
         border border-surface-300 hover:border-surface-400 dark:border-surface-600 dark:hover:border-surface-500
         p-focus:border-primary
@@ -73,8 +73,8 @@ const theme = ref<MultiSelectPassThroughOptions>({
         removeIcon: `cursor-pointer text-base w-4 h-4 rounded-full text-white dark:text-surface-0`
     },
     dropdown: `flex items-center justify-center shrink-0 bg-transparent
-        text-surface-400 w-10 rounded-e-md`,
-    overlay: `absolute top-0 left-0 rounded-md p-portal-self:min-w-full
+        text-surface-400 w-10 rounded-e-[var(--p-content-border-radius)]`,
+    overlay: `absolute top-0 left-0 rounded-[var(--p-content-border-radius)] p-portal-self:min-w-full
         bg-surface-0 dark:bg-surface-900
         border border-surface-200 dark:border-surface-700
         text-surface-700 dark:text-surface-0
@@ -101,7 +101,7 @@ const theme = ref<MultiSelectPassThroughOptions>({
         root: `relative flex-auto`
     },
     pcFilter: {
-        root: `w-full appearance-none rounded-md outline-hidden
+        root: `w-full appearance-none rounded-[var(--p-content-border-radius)] outline-hidden
             bg-surface-0 dark:bg-surface-950
             text-surface-700 dark:text-surface-0
             placeholder:text-surface-500 dark:placeholder:text-surface-400

--- a/ui/src/components/Select.vue
+++ b/ui/src/components/Select.vue
@@ -44,7 +44,7 @@ const props = defineProps<Props>();
 const attrs = useAttrs();
 
 const theme = ref<SelectPassThroughOptions>({
-    root: `inline-flex cursor-pointer relative select-none rounded-md p-fluid:flex
+    root: `inline-flex cursor-pointer relative select-none rounded-[var(--p-content-border-radius)] p-fluid:flex
         items-center
         bg-surface-0 dark:bg-surface-950
         border border-surface-300 hover:border-surface-400 dark:border-surface-700 dark:hover:border-surface-600
@@ -64,8 +64,8 @@ const theme = ref<SelectPassThroughOptions>({
         p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
         p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem]`,
     dropdown: `flex items-center justify-center shrink-0 bg-transparent
-        text-surface-400 w-10 rounded-e`,
-    overlay: `absolute top-0 left-0 rounded-md p-portal-self:min-w-full
+        text-surface-400 w-10 rounded-e-[var(--p-content-border-radius)]`,
+    overlay: `absolute top-0 left-0 rounded-[var(--p-content-border-radius)] p-portal-self:min-w-full
         bg-surface-0 dark:bg-surface-900
         border border-surface-200 dark:border-surface-700
         text-surface-700 dark:text-surface-0
@@ -75,7 +75,7 @@ const theme = ref<SelectPassThroughOptions>({
         root: `relative flex-auto`
     },
     pcFilter: {
-        root: `w-full appearance-none rounded-md outline-hidden
+        root: `w-full appearance-none rounded-[var(--p-content-border-radius)] outline-hidden
             bg-surface-0 dark:bg-surface-950
             text-surface-700 dark:text-surface-0
             placeholder:text-surface-500 dark:placeholder:text-surface-400

--- a/ui/src/components/Textarea.vue
+++ b/ui/src/components/Textarea.vue
@@ -17,7 +17,7 @@ const props = defineProps<Props>();
 const attrs = useAttrs();
 
 const theme = ref<TextareaPassThroughOptions>({
-    root: `appearance-none rounded-md outline-hidden
+    root: `appearance-none rounded-[var(--p-content-border-radius)] outline-hidden
         bg-surface-0 dark:bg-surface-950
         p-filled:bg-surface-50 dark:p-filled:bg-surface-800
         text-surface-700 dark:text-surface-0


### PR DESCRIPTION
## Summary
- Apply `--p-content-border-radius` rounding to core form components (InputText, Textarea, Select, MultiSelect, FileUpload, DatePicker)
- Ensure select overlays, dropdowns, and filters respect theme border radius

## Testing
- `cd ui && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab768773ec83259f29ebcdce8c7e6b