### PR TITLE
Align component rounding with theme

### DIFF
--- a/ui/src/components/AutoComplete.vue
+++ b/ui/src/components/AutoComplete.vue
@@ -27,7 +27,7 @@ const attrs = useAttrs();
 const theme = ref<AutoCompletePassThroughOptions>({
     root: `inline-flex p-fluid:flex`,
     pcInputText: {
-        root: `appearance-none rounded-md outline-hidden
+        root: `appearance-none rounded-[var(--p-content-border-radius)] outline-hidden
             bg-surface-0 dark:bg-surface-950
             p-filled:bg-surface-50 dark:p-filled:bg-surface-800
             text-surface-700 dark:text-surface-0
@@ -47,7 +47,7 @@ const theme = ref<AutoCompletePassThroughOptions>({
     },
     inputMultiple: `m-0 list-none cursor-text overflow-hidden flex items-center flex-wrap
         px-3 py-1 not-p-empty:px-1 gap-1 text-surface-700 dark:text-surface-0 bg-surface-0 dark:bg-surface-950
-        border border-surface-300 dark:border-surface-700 rounded-md p-has-dropdown:rounded-e-none w-full
+        border border-surface-300 dark:border-surface-700 rounded-[var(--p-content-border-radius)] p-has-dropdown:rounded-e-none w-full
         hover:border-surface-400 dark:hover:border-surface-600 p-focus:border-primary
         p-invalid:border-red-400 dark:p-invalid:border-red-300
         p-filled:bg-surface-50 dark:p-filled:bg-surface-800
@@ -56,7 +56,7 @@ const theme = ref<AutoCompletePassThroughOptions>({
         transition-colors duration-200 outline-none`,
     chipItem: ``,
     pcChip: {
-        root: `inline-flex items-center rounded-sm gap-2 px-3 py-1
+        root: `inline-flex items-center rounded-[var(--p-content-border-radius)] gap-2 px-3 py-1
             bg-primary-500 dark:bg-primary-500
             text-white dark:text-surface-0
             has-[img]:pt-1 has-[img]:pb-1
@@ -74,7 +74,7 @@ const theme = ref<AutoCompletePassThroughOptions>({
     input: `border-none outline-none bg-transparent m-0 p-0 shadow-none rounded-none w-full text-inherit
         placeholder:text-surface-500 dark:placeholder:text-surface-400`,
     loader: `absolute top-1/2 -mt-2 end-3 p-has-dropdown:end-[3.25rem] animate-spin`,
-    dropdown: `cursor-pointer inline-flex items-center justify-center select-none overflow-hidden relative w-10 shrink-0 rounded-e-md
+    dropdown: `cursor-pointer inline-flex items-center justify-center select-none overflow-hidden relative w-10 shrink-0 rounded-e-[var(--p-content-border-radius)]
         border border-s-0 border-surface-300 dark:border-surface-700
         bg-surface-100 enabled:hover:bg-surface-200 enabled:active:bg-surface-300
         text-surface-600 enabled:hover:text-surface-700 enabled:hover:active:text-surface-800
@@ -83,7 +83,7 @@ const theme = ref<AutoCompletePassThroughOptions>({
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-primary
         transition-colors duration-200`,
     dropdownIcon: ``,
-    overlay: `p-portal-self:min-w-full absolute top-0 left-0 rounded-md
+    overlay: `p-portal-self:min-w-full absolute top-0 left-0 rounded-[var(--p-content-border-radius)]
         bg-surface-0 dark:bg-surface-900
         border border-surface-200 dark:border-surface-700
         text-surface-700 dark:text-surface-0
@@ -93,7 +93,7 @@ const theme = ref<AutoCompletePassThroughOptions>({
     list: `m-0 p-1 list-none flex flex-col gap-[2px]`,
     optionGroup: `m-0 px-3 py-2 text-surface-500 dark:text-surface-400 font-semibold bg-transparent`,
     option: `cursor-pointer font-normal whitespace-nowrap relative overflow-hidden flex items-center
-    px-3 py-1.5 border-none text-surface-700 dark:text-surface-0 bg-transparent rounded-sm
+    px-3 py-1.5 border-none text-surface-700 dark:text-surface-0 bg-transparent rounded-[var(--p-content-border-radius)]
     p-focus:bg-surface-100 dark:p-focus:bg-surface-800 p-focus:text-surface-800 dark:p-focus:text-surface-0
     p-selected:bg-primary-500 p-focus:p-selected:bg-primary-500 p-selected:text-white p-focus:p-selected:text-white dark:p-selected:bg-primary-500 dark:p-focus:p-selected:bg-primary-500
     transition-colors duration-200 text-sm`,

--- a/ui/src/components/ButtonGroup.vue
+++ b/ui/src/components/ButtonGroup.vue
@@ -21,7 +21,7 @@ const props = defineProps<Props>();
 const attrs = useAttrs();
 
 const theme = ref<ButtonGroupPassThroughOptions>({
-    root: `*:rounded-none *:first:rounded-s-md *:last:rounded-e-md
+    root: `*:rounded-none *:first:rounded-s-[var(--p-content-border-radius)] *:last:rounded-e-[var(--p-content-border-radius)]
         *:focus-visible:relative *:focus-visible:z-10 *:not-last:border-r-0
         *:p-outlined:border-surface-300 *:enabled:hover:p-outlined:border-surface-400 *:enabled:active:p-outlined:border-surface-300
         dark:*:p-outlined:border-surface-700 dark:*:enabled:hover:p-outlined:border-surface-600 dark:*:enabled:active:p-outlined:border-surface-600`

--- a/ui/src/components/Card.vue
+++ b/ui/src/components/Card.vue
@@ -26,7 +26,7 @@ const props = withDefaults(defineProps<Props>(), {
 const attrs = useAttrs();
 
 const theme = computed<CardPassThroughOptions>(() => ({
-    root: `flex flex-col rounded-lg
+    root: `flex flex-col rounded-[var(--p-content-border-radius)]
         bg-surface-0 dark:bg-surface-800
         text-surface-700 dark:text-surface-0
         border border-surface-300 dark:border-surface-700

--- a/ui/src/components/InputNumber.vue
+++ b/ui/src/components/InputNumber.vue
@@ -32,7 +32,7 @@ const theme = ref<InputNumberPassThroughOptions>({
     root: `inline-flex relative
         p-vertical:flex-col p-fluid:w-full`,
     pcInputText: {
-        root: `appearance-none rounded-md outline-hidden flex-auto
+        root: `appearance-none rounded-[var(--p-content-border-radius)] outline-hidden flex-auto
         bg-surface-0 dark:bg-surface-950
         p-filled:bg-surface-50 dark:p-filled:bg-surface-800
         text-surface-700 dark:text-surface-0
@@ -64,9 +64,9 @@ const theme = ref<InputNumberPassThroughOptions>({
         dark:text-surface-400 dark:enabled:hover:text-surface-300 dark:enabled:active:text-surface-200
         transition-colors duration-200 disabled:pointer-events-none
         p-stacked:relative p-stacked:flex-auto p-stacked:border-none
-        p-stacked:p-0 p-stacked:rounded-tr-[5px]
-        p-horizontal:order-3 p-horizontal:rounded-e-md p-horizontal:border-s-0
-        p-vertical:py-2 p-vertical:order-1 p-vertical:rounded-ss-md p-vertical:rounded-se-md p-vertical:w-full p-vertical:border-b-0`,
+        p-stacked:p-0 p-stacked:rounded-tr-[var(--p-content-border-radius)]
+        p-horizontal:order-3 p-horizontal:rounded-e-[var(--p-content-border-radius)] p-horizontal:border-s-0
+        p-vertical:py-2 p-vertical:order-1 p-vertical:rounded-ss-[var(--p-content-border-radius)] p-vertical:rounded-se-[var(--p-content-border-radius)] p-vertical:w-full p-vertical:border-b-0`,
     incrementIcon: ``,
     decrementButton: `flex items-center justify-center grow-0 shrink-0 basis-auto cursor-pointer w-10
         bg-transparent enabled:hover:bg-surface-100 enabled:active:bg-surface-200
@@ -77,9 +77,9 @@ const theme = ref<InputNumberPassThroughOptions>({
         dark:text-surface-400 dark:enabled:hover:text-surface-300 dark:enabled:active:text-surface-200
         transition-colors duration-200 disabled:pointer-events-none
         p-stacked:relative p-stacked:flex-auto p-stacked:border-none
-        p-stacked:p-0 p-stacked:rounded-br-[5px]
-        p-horizontal:order-1 p-horizontal:rounded-s-md p-horizontal:border-e-0
-        p-vertical:py-2 p-vertical:order-3 p-vertical:rounded-ee-md p-vertical:rounded-es-md p-vertical:w-full p-vertical:border-t-0`,
+        p-stacked:p-0 p-stacked:rounded-br-[var(--p-content-border-radius)]
+        p-horizontal:order-1 p-horizontal:rounded-s-[var(--p-content-border-radius)] p-horizontal:border-e-0
+        p-vertical:py-2 p-vertical:order-3 p-vertical:rounded-ee-[var(--p-content-border-radius)] p-vertical:rounded-es-[var(--p-content-border-radius)] p-vertical:w-full p-vertical:border-t-0`,
     decrementIcon: ``
 });
 

--- a/ui/src/components/MultiSelect.vue
+++ b/ui/src/components/MultiSelect.vue
@@ -65,7 +65,7 @@ const theme = ref<MultiSelectPassThroughOptions>({
         p-large:text-lg p-large:px-[0.875rem] p-large:py-[0.625rem] p-disabled:opacity-50 p-disabled:pointer-events-none`,
     chipItem: ``,
     pcChip: {
-        root: `inline-flex items-center gap-2 px-3 py-[5px] rounded-sm
+        root: `inline-flex items-center gap-2 px-3 py-[5px] rounded-[var(--p-content-border-radius)]
             bg-primary-500 dark:bg-primary-500
             text-white dark:text-surface-0
             has-[img]:pt-1 has-[img]:pb-1
@@ -85,7 +85,7 @@ const theme = ref<MultiSelectPassThroughOptions>({
         input: `peer cursor-pointer disabled:cursor-default appearance-none
             absolute start-0 top-0 w-full h-full m-0 p-0 opacity-0 z-10
             border border-transparent rounded-xs`,
-        box: `flex justify-center items-center rounded-sm w-5 h-5
+        box: `flex justify-center items-center rounded-[var(--p-content-border-radius)] w-5 h-5
             border border-surface-300 dark:border-surface-700
             bg-surface-0 dark:bg-surface-950
             text-surface-700 dark:text-surface-0
@@ -121,7 +121,7 @@ const theme = ref<MultiSelectPassThroughOptions>({
     list: `m-0 p-1 list-none gap-[2px] flex flex-col`,
     optionGroup: `m-0 px-3 py-2 bg-transparent text-surface-500 dark:text-surface-400 font-semibold`,
     option: `cursor-pointer font-normal whitespace-nowrap relative overflow-hidden flex items-center gap-2 px-3 py-1.5
-        rounded-sm text-surface-700 dark:text-surface-0 bg-transparent border-none
+        rounded-[var(--p-content-border-radius)] text-surface-700 dark:text-surface-0 bg-transparent border-none
         p-focus:bg-surface-100 dark:p-focus:bg-surface-800 p-focus:text-surface-800 dark:p-focus:text-surface-0
         transition-colors duration-200 text-sm`,
     optionLabel: ``,
@@ -130,7 +130,7 @@ const theme = ref<MultiSelectPassThroughOptions>({
         input: `peer cursor-pointer disabled:cursor-default appearance-none
             absolute start-0 top-0 w-full h-full m-0 p-0 opacity-0 z-10
             border border-transparent rounded-xs`,
-        box: `flex justify-center items-center rounded-sm w-5 h-5
+        box: `flex justify-center items-center rounded-[var(--p-content-border-radius)] w-5 h-5
             border border-surface-300 dark:border-surface-700
             bg-surface-0 dark:bg-surface-950
             text-surface-700 dark:text-surface-0


### PR DESCRIPTION
## Summary
- use theme border radius token across AutoComplete and MultiSelect
- apply theme rounding to currency InputNumber controls
- align Card and ButtonGroup rounding with theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab79cd1e508325835d945f0a7c21bc