### PR TITLE
feat(button): add fully rounded variant

### DIFF
--- a/playground/src/pages/components/Buttons.vue
+++ b/playground/src/pages/components/Buttons.vue
@@ -87,15 +87,16 @@ const groups = [
   { title: 'Buttons (large-text)', attrs: { size: 'large', text: true } },
 ];
 
-const states = [
-  { label: 'Default', attrs: {} },
-  { label: 'Search', attrs: { icon: 'pi pi-search' } },
-  { label: 'Raised', attrs: { raised: true } },
-  { label: 'Loading', attrs: { loading: true } },
-  { label: 'Disabled', attrs: { disabled: true } },
-];
+  const states = [
+    { label: 'Default', attrs: {} },
+    { label: 'Search', attrs: { icon: 'pi pi-search' } },
+    { label: 'Raised', attrs: { raised: true } },
+    { label: 'Rounded', attrs: { rounded: true } },
+    { label: 'Loading', attrs: { loading: true } },
+    { label: 'Disabled', attrs: { disabled: true } },
+  ];
 
-const buttonStates = states.filter(({ label }) => label !== 'Raised');
+  const buttonStates = states.filter(({ label }) => !['Raised', 'Rounded'].includes(label));
 
 const iconStates = [
   { icon: 'pi pi-check', attrs: {}, ariaLabel: 'Check' },

--- a/ui/src/components/Button.vue
+++ b/ui/src/components/Button.vue
@@ -33,7 +33,7 @@ const theme = ref<ButtonPassThroughOptions>({
         p-large:p-icon-only:w-[42px] p-large:p-icon-only:h-[42px] p-large:p-icon-only:p-0
         p-small:text-sm p-small:px-[0.625rem] p-small:py-[0.375rem]
         p-large:text-[1.125rem] p-large:px-[0.875rem] p-large:py-[0.625rem]
-        p-raised:shadow-sm p-rounded:rounded-[var(--p-rounded-4)]
+        p-raised:shadow-sm p-rounded:rounded-full
         p-outlined:bg-transparent enabled:hover:p-outlined:bg-gray-100 enabled:active:p-outlined:bg-gray-200
         p-outlined:border-surface-300 enabled:hover:p-outlined:border-surface-400 enabled:active:p-outlined:border-surface-300
         p-outlined:text-gray-700 enabled:hover:p-outlined:text-gray-700 enabled:active:p-outlined:text-gray-700


### PR DESCRIPTION
## Summary
- ensure rounded button renders with full border radius regardless of theme
- showcase rounded button in playground demo

## Testing
- `npm test` (ui)
- `npm test` (playground, fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68ab7a7729f083258e4539fd75235b04