### PR TITLE
style: align UI rounding with theme

### DIFF
--- a/ui/src/components/Alert.vue
+++ b/ui/src/components/Alert.vue
@@ -47,7 +47,7 @@ const props = withDefaults(defineProps<Props>(), {
 const attrs = useAttrs();
 
 const theme = computed<AlertPassThroughOptions>(() => ({
-    root: `w-full p-4 flex border items-center space-x-4 rounded-md text-gray-900 dark:text-surface-100 ${
+    root: `w-full p-4 flex border items-center space-x-4 rounded-[var(--p-content-border-radius)] text-gray-900 dark:text-surface-100 ${
         props.warning
             ? 'bg-yellow-100 border-yellow-300 dark:bg-yellow-700 dark:border-yellow-600'
             : 'bg-surface-50 border-surface-300 dark:bg-surface-700 dark:border-surface-600'

--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -37,8 +37,8 @@
                                         pt: {
                                             root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] ml-3',
                                             text: autoDark
-                                                ? 'text-sm p-2 border border-surface-300 bg-white text-surface-700 dark:bg-surface-700 dark:border-surface-800 dark:text-white rounded whitespace-pre-line'
-                                                : 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+                                                ? 'text-sm p-2 border border-surface-300 bg-white text-surface-700 dark:bg-surface-700 dark:border-surface-800 dark:text-white rounded-[var(--p-content-border-radius)] whitespace-pre-line'
+                                                : 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
                                         }
                                 }"
                                 class="relative flex items-center justify-center w-full h-12 mt-2 rounded"

--- a/ui/src/components/App/Page/SideNav.vue
+++ b/ui/src/components/App/Page/SideNav.vue
@@ -94,7 +94,7 @@ const { items, linkComponent } = props;
 
 const tooltipPt = {
     root: 'absolute ml-2 shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-    text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+    text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
 };
 
 const isActive = (item: NavItem) =>

--- a/ui/src/components/App/Table/Actions.vue
+++ b/ui/src/components/App/Table/Actions.vue
@@ -12,7 +12,7 @@
                     value: menuItem?.tooltip ?? null,
                     pt: {
                         root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] mt-1',
-                        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+                        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
                     }
                 }"
                 class="pl-3"
@@ -74,7 +74,7 @@
                         value: 'Clear selection',
                         pt: {
                             root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] mt-1',
-                            text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+                            text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
                         }
                     }"
                     type="button"

--- a/ui/src/components/App/Table/Table.vue
+++ b/ui/src/components/App/Table/Table.vue
@@ -13,7 +13,7 @@
                             value: 'Customize columns',
                             pt: {
                                 root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-                                text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+                                text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
                             }
                         }"
                         class="bg-white border border-gray-300 cursor-pointer text-surface-600 dark:text-surface-400 hover:text-surface-800 dark:hover:text-surface-300 h-[38px] w-[38px] flex items-center justify-center rounded-bl-lg rounded-br-lg"

--- a/ui/src/components/Editor/Tools/BoldTool.vue
+++ b/ui/src/components/Editor/Tools/BoldTool.vue
@@ -29,7 +29,7 @@ const tooltip = {
     value: 'Bold',
     pt: {
         root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };
 </script>

--- a/ui/src/components/Editor/Tools/BulletListTool.vue
+++ b/ui/src/components/Editor/Tools/BulletListTool.vue
@@ -27,7 +27,7 @@ const tooltip = {
     value: 'Bullet list',
     pt: {
         root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };
 </script>

--- a/ui/src/components/Editor/Tools/ClearFormattingTool.vue
+++ b/ui/src/components/Editor/Tools/ClearFormattingTool.vue
@@ -23,7 +23,7 @@ const tooltip = {
     value: 'Clear formatting',
     pt: {
         root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };
 </script>

--- a/ui/src/components/Editor/Tools/ItalicTool.vue
+++ b/ui/src/components/Editor/Tools/ItalicTool.vue
@@ -27,7 +27,7 @@ const tooltip = {
     value: 'Italic',
     pt: {
         root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };
 </script>

--- a/ui/src/components/Editor/Tools/LinkTool.vue
+++ b/ui/src/components/Editor/Tools/LinkTool.vue
@@ -79,7 +79,7 @@ const tooltip = {
     value: 'Add link',
     pt: {
         root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };
 </script>

--- a/ui/src/components/Editor/Tools/OrderedListTool.vue
+++ b/ui/src/components/Editor/Tools/OrderedListTool.vue
@@ -27,7 +27,7 @@ const tooltip = {
     value: 'Numbered list',
     pt: {
         root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };
 </script>

--- a/ui/src/components/Editor/Tools/StrikeTool.vue
+++ b/ui/src/components/Editor/Tools/StrikeTool.vue
@@ -27,7 +27,7 @@ const tooltip = {
     value: 'Strikethrough',
     pt: {
         root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+        text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };
 </script>

--- a/ui/src/components/Errors.vue
+++ b/ui/src/components/Errors.vue
@@ -84,7 +84,7 @@ onMounted(() => {
 });
 
 const theme = ref<ErrorsPassThroughOptions>({
-    root: 'rounded-md bg-red-50 dark:bg-red-900/20 border border-red-300 dark:border-red-800/70 p-4 cursor-pointer',
+    root: 'rounded-[var(--p-content-border-radius)] bg-red-50 dark:bg-red-900/20 border border-red-300 dark:border-red-800/70 p-4 cursor-pointer',
     header: 'flex',
     icon: 'relative top-1 shrink-0 text-red-700 self-start flex items-center',
     titleContainer: 'ml-2 basis-full',

--- a/ui/src/components/Menu.vue
+++ b/ui/src/components/Menu.vue
@@ -25,11 +25,11 @@ const theme = ref<MenuPassThroughOptions>({
     root: `bg-surface-0 dark:bg-surface-900
         text-surface-700 dark:text-surface-0
         border border-surface-200 dark:border-surface-700
-        rounded-md min-w-52
+        rounded-[var(--p-content-border-radius)] min-w-52
         p-popup:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_2px_4px_-2px_rgba(0,0,0,0.1)]`,
     list: `m-0 p-1 list-none outline-none flex flex-col gap-[2px]`,
     item: `p-disabled:opacity-60 p-disabled:pointer-events-none`,
-    itemContent: `group transition-colors duration-200 rounded-sm text-surface-700 dark:text-surface-0
+    itemContent: `group transition-colors duration-200 rounded-[var(--p-content-border-radius)] text-surface-700 dark:text-surface-0
         p-focus:bg-surface-100 dark:p-focus:bg-surface-800 p-focus:text-surface-800 dark:p-focus:text-surface-0
         hover:bg-surface-100 dark:hover:bg-surface-800 hover:text-surface-800 dark:hover:text-surface-0`,
     itemLink: `cursor-pointer flex items-center no-underline overflow-hidden relative text-inherit

--- a/ui/src/components/Popover.vue
+++ b/ui/src/components/Popover.vue
@@ -25,7 +25,7 @@ const theme = ref<PopoverPassThroughOptions>({
     root: `mt-[5px] p-flipped:-mt-[5px] p-flipped:mb-[5px]
         bg-surface-0 dark:bg-surface-900 text-surface-800 dark:text-surface-0 text-sm
         dark:border dark:border-surface-700
-        rounded shadow-floating`,
+        rounded-[var(--p-content-border-radius)] shadow-floating`,
     content: `p-3`,
     transition: {
         enterFromClass: 'opacity-0 scale-y-75',

--- a/ui/src/components/ProgressBar.vue
+++ b/ui/src/components/ProgressBar.vue
@@ -21,7 +21,7 @@ const props = defineProps<Props>();
 const attrs = useAttrs();
 
 const theme = ref<ProgressBarPassThroughOptions>({
-    root: `relative overflow-hidden h-5 bg-surface-200 dark:bg-surface-700 rounded-md`,
+    root: `relative overflow-hidden h-5 bg-surface-200 dark:bg-surface-700 rounded-[var(--p-content-border-radius)]`,
     value: `m-0 bg-primary-500
         p-determinate:h-full p-determinate:w-0 p-determinate:absolute p-determinate:flex p-determinate:items-center p-determinate:justify-center
         p-determinate:overflow-hidden p-determinate:transition-[width] p-determinate:duration-1000 p-determinate:ease-in-out

--- a/ui/src/components/Select.vue
+++ b/ui/src/components/Select.vue
@@ -95,7 +95,7 @@ const theme = ref<SelectPassThroughOptions>({
     optionGroup: `m-0 px-3 py-2 bg-transparent text-surface-500 dark:text-surface-400 font-semibold`,
     optionGroupLabel: ``,
     option: `cursor-pointer font-normal whitespace-nowrap relative overflow-hidden flex items-center
-        px-3 py-1.5 border-none text-surface-700 dark:text-surface-0 bg-transparent rounded-sm
+        px-3 py-1.5 border-none text-surface-700 dark:text-surface-0 bg-transparent rounded-[var(--p-content-border-radius)]
         p-focus:bg-surface-100 dark:p-focus:bg-surface-800 p-focus:text-surface-800 dark:p-focus:text-surface-0
         p-selected:bg-primary-400 p-focus:p-selected:bg-primary-400 p-selected:text-white p-focus:p-selected:text-white dark:p-selected:bg-primary-600 dark:p-focus:p-selected:bg-primary-600
         transition-colors duration-200 text-sm`,

--- a/ui/src/components/TooltipIcon.vue
+++ b/ui/src/components/TooltipIcon.vue
@@ -40,7 +40,7 @@ const mergedPt = computed(() => ptMerge(theme.value, props.pt));
 
 const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
     root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
-    text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded whitespace-pre-line'
+    text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
 });
 
 const tooltip = computed(() => ({


### PR DESCRIPTION
## Summary
- ensure select option rounding uses theme border radius
- apply theme-based rounding to alerts, errors, progress bar, popover
- normalize tooltip and menu item rounding to theme variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab7c47a56c8325917c1a10a7430588