### PR TITLE
feat(ui): allow nav color customization

### DIFF
--- a/docs/ui/application/nav-sidebar.md
+++ b/docs/ui/application/nav-sidebar.md
@@ -35,6 +35,8 @@ const navItems = [
 - `items: NavItem[]` – sections and links displayed in the sidebar.
 - `logoLinkPath: string` – root link. Default `'/'`.
 - `linkComponent: string | object` – component used for links. Default `'a'`.
+- `backgroundClass: string` – optional classes for the sidebar background and border. Defaults to a primary `900` tone in dark mode.
+- `activeClass: string` – class applied to active links. Defaults to a primary `700` tone in dark mode.
 
 ## Slots
 - `logo` – brand image or text.

--- a/docs/ui/application/nav-sidebar.md
+++ b/docs/ui/application/nav-sidebar.md
@@ -36,7 +36,7 @@ const navItems = [
 - `logoLinkPath: string` – root link. Default `'/'`.
 - `linkComponent: string | object` – component used for links. Default `'a'`.
 - `backgroundClass: string` – optional classes for the sidebar background and border. Defaults to a primary `900` tone in dark mode.
-- `activeClass: string` – class applied to active links. Defaults to a primary `700` tone in dark mode.
+- `activeClass: string` – class applied to active links. Defaults to a white background with primary text/icons.
 
 ## Slots
 - `logo` – brand image or text.

--- a/docs/ui/application/nav-topbar.md
+++ b/docs/ui/application/nav-topbar.md
@@ -35,7 +35,7 @@ const navItems = [
 - `logoLinkPath: string` – root link. Default `'/'`.
 - `widthClass: string` – max width container class. Default `'max-w-screen-2xl'`.
 - `backgroundClass: string` – optional classes for the top bar background and border. Defaults to a primary `900` tone in dark mode.
-- `activeClass: string` – class applied to active links. Defaults to a primary `700` tone in dark mode.
+- `activeClass: string` – class applied to active links. Defaults to a white background with primary text.
 
 ## Slots
 - `logo` – brand image or text.

--- a/docs/ui/application/nav-topbar.md
+++ b/docs/ui/application/nav-topbar.md
@@ -34,6 +34,8 @@ const navItems = [
 - `linkComponent: string | object` – component used for links. Default `'a'`.
 - `logoLinkPath: string` – root link. Default `'/'`.
 - `widthClass: string` – max width container class. Default `'max-w-screen-2xl'`.
+- `backgroundClass: string` – optional classes for the top bar background and border. Defaults to a primary `900` tone in dark mode.
+- `activeClass: string` – class applied to active links. Defaults to a primary `700` tone in dark mode.
 
 ## Slots
 - `logo` – brand image or text.

--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -116,13 +116,13 @@ const containerClass = computed(() => {
         ? 'text-surface-700 dark:text-white/80'
         : 'dark text-white/80';
     const bg = props.backgroundClass || (props.autoDark
-        ? 'bg-surface-100 dark:bg-primary-900 border-surface-200 dark:border-primary-700'
-        : 'bg-primary-900 border-primary-700');
+        ? 'bg-surface-100 dark:bg-primary-950 border-surface-200 dark:border-primary-950'
+        : 'bg-primary-950 border-primary-950');
     return `${base} ${bg}`;
 });
 
 const linkClass = (item) => {
-    const activeCls = props.activeClass || 'bg-white text-primary-900';
+    const activeCls = props.activeClass || 'bg-white text-primary-950';
     if (props.autoDark) {
         const baseCls =
             'text-surface-600 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-primary-800';

--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -122,15 +122,12 @@ const containerClass = computed(() => {
 });
 
 const linkClass = (item) => {
+    const activeCls = props.activeClass || 'bg-white text-primary-900';
     if (props.autoDark) {
-        const activeCls =
-            props.activeClass ||
-            'bg-surface-200 dark:bg-primary-700 text-surface-900 dark:text-white';
         const baseCls =
             'text-surface-600 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-primary-800';
         return isActive(item) ? activeCls : baseCls;
     }
-    const activeCls = props.activeClass || 'bg-primary-700 text-white';
     const baseCls = 'text-white hover:bg-primary-800';
     return isActive(item) ? activeCls : baseCls;
 };

--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -1,11 +1,7 @@
 <template>
     <div
         class="relative flex flex-col items-center w-16 h-full overflow-hidden border-r z-[99]"
-        :class="
-            autoDark
-                ? 'text-surface-700 dark:text-white/80 bg-surface-100 dark:bg-surface-800 border-surface-200 dark:border-surface-700'
-                : 'dark text-white/80 bg-surface-800 border-surface-700'
-        "
+        :class="containerClass"
     >
         <component :is="linkComponent" class="flex items-center justify-center h-14" :href="logoLinkPath">
             <div class="flex-shrink-0">
@@ -88,6 +84,14 @@ const props = defineProps({
     autoDark: {
         type: Boolean,
         default: false
+    },
+    backgroundClass: {
+        type: String,
+        default: '',
+    },
+    activeClass: {
+        type: String,
+        default: '',
     }
 });
 
@@ -107,18 +111,27 @@ const getIcon = (item) => {
 
 const hasActions = computed(() => hasSlotContent(slots.actions));
 
+const containerClass = computed(() => {
+    const base = props.autoDark
+        ? 'text-surface-700 dark:text-white/80'
+        : 'dark text-white/80';
+    const bg = props.backgroundClass || (props.autoDark
+        ? 'bg-surface-100 dark:bg-primary-900 border-surface-200 dark:border-primary-700'
+        : 'bg-primary-900 border-primary-700');
+    return `${base} ${bg}`;
+});
+
 const linkClass = (item) => {
     if (props.autoDark) {
-        return [
-            'text-surface-600 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-700',
-            isActive(item)
-                ? 'bg-surface-200 dark:bg-surface-700 text-surface-900 dark:text-white'
-                : ''
-        ].join(' ');
+        const activeCls =
+            props.activeClass ||
+            'bg-surface-200 dark:bg-primary-700 text-surface-900 dark:text-white';
+        const baseCls =
+            'text-surface-600 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-primary-800';
+        return isActive(item) ? activeCls : baseCls;
     }
-    return [
-        'hover:bg-surface-600 text-white',
-        isActive(item) ? 'bg-surface-500/80' : ''
-    ].join(' ');
+    const activeCls = props.activeClass || 'bg-primary-700 text-white';
+    const baseCls = 'text-white hover:bg-primary-800';
+    return isActive(item) ? activeCls : baseCls;
 };
 </script>

--- a/ui/src/components/App/Nav/Topbar.vue
+++ b/ui/src/components/App/Nav/Topbar.vue
@@ -132,8 +132,8 @@ const hasActions = computed(() => hasSlotContent(slots.actions));
 
 const containerClass = computed(() => {
     const bg = props.backgroundClass || (props.autoDark
-        ? 'bg-surface-100 dark:bg-primary-900 border-surface-200 dark:border-primary-700'
-        : 'dark bg-primary-900 border-primary-700');
+        ? 'bg-surface-100 dark:bg-primary-950 border-surface-200 dark:border-primary-950'
+        : 'dark bg-primary-950 border-primary-950');
     return bg;
 });
 

--- a/ui/src/components/App/Nav/Topbar.vue
+++ b/ui/src/components/App/Nav/Topbar.vue
@@ -138,17 +138,15 @@ const containerClass = computed(() => {
 });
 
 const menuActiveClass = computed(() => {
-    return props.activeClass || 'bg-surface-200 dark:bg-primary-700 dark:text-white';
+    return props.activeClass || 'bg-white text-primary-900';
 });
 
 const linkClass = (item) => {
+    const activeCls = props.activeClass || 'bg-white text-primary-900';
     if (props.autoDark) {
-        const activeCls = props.activeClass ||
-            'bg-surface-200 dark:bg-primary-700 text-surface-900 dark:text-white';
         const baseCls = 'text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-primary-800 hover:text-surface-900 dark:hover:text-white';
         return isActive(item) ? activeCls : baseCls;
     }
-    const activeCls = props.activeClass || 'bg-primary-700 text-white';
     const baseCls = 'text-gray-300 hover:bg-primary-800 hover:text-white';
     return isActive(item) ? activeCls : baseCls;
 };

--- a/ui/src/components/App/Nav/Topbar.vue
+++ b/ui/src/components/App/Nav/Topbar.vue
@@ -1,11 +1,7 @@
 <template>
     <nav
         class="w-full border-b shadow-lg"
-        :class="
-            autoDark
-                ? 'bg-surface-100 dark:bg-surface-800 border-surface-200 dark:border-surface-700'
-                : 'dark bg-surface-800 border-surface-700'
-        "
+        :class="containerClass"
     >
         <div class="mx-auto px-4" :class="widthClass">
             <div class="flex h-16 items-center justify-between">
@@ -54,9 +50,7 @@
                                             v-bind="props.action"
                                             :href="item.href"
                                             class="flex items-center w-full px-2 py-1 text-sm rounded-[var(--p-content-border-radius)]"
-                                            :class="{
-                                                'bg-surface-200 dark:bg-surface-800 dark:text-white': isActive(item)
-                                            }"
+                                            :class="isActive(item) ? menuActiveClass : ''"
                                         >
                                             <span :class="item.icon" />
                                             <span class="ml-2">{{ item.label }}</span>
@@ -103,6 +97,14 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+    backgroundClass: {
+        type: String,
+        default: '',
+    },
+    activeClass: {
+        type: String,
+        default: '',
+    },
 });
 
 const menuRefs = reactive({});
@@ -128,14 +130,26 @@ const isActive = (item) => {
 
 const hasActions = computed(() => hasSlotContent(slots.actions));
 
+const containerClass = computed(() => {
+    const bg = props.backgroundClass || (props.autoDark
+        ? 'bg-surface-100 dark:bg-primary-900 border-surface-200 dark:border-primary-700'
+        : 'dark bg-primary-900 border-primary-700');
+    return bg;
+});
+
+const menuActiveClass = computed(() => {
+    return props.activeClass || 'bg-surface-200 dark:bg-primary-700 dark:text-white';
+});
+
 const linkClass = (item) => {
     if (props.autoDark) {
-        return isActive(item)
-            ? 'bg-surface-200 dark:bg-surface-700 text-surface-900 dark:text-white'
-            : 'text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-700 hover:text-surface-900 dark:hover:text-white';
+        const activeCls = props.activeClass ||
+            'bg-surface-200 dark:bg-primary-700 text-surface-900 dark:text-white';
+        const baseCls = 'text-surface-700 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-primary-800 hover:text-surface-900 dark:hover:text-white';
+        return isActive(item) ? activeCls : baseCls;
     }
-    return isActive(item)
-        ? 'bg-surface-900 text-white'
-        : 'text-gray-300 hover:bg-gray-700 hover:text-white';
+    const activeCls = props.activeClass || 'bg-primary-700 text-white';
+    const baseCls = 'text-gray-300 hover:bg-primary-800 hover:text-white';
+    return isActive(item) ? activeCls : baseCls;
 };
 </script>


### PR DESCRIPTION
## Summary
- default app navs to primary-900 backgrounds in dark mode
- allow custom background and active colors for nav sidebar and topbar
- document new nav color customization props

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab80deb81c8325abd8ceb8abced727