### PR TITLE
fix: global tooltip z-index

### DIFF
--- a/ui/src/components/App/Nav/Sidebar.vue
+++ b/ui/src/components/App/Nav/Sidebar.vue
@@ -35,7 +35,7 @@
                                 v-tooltip.right="{
                                     value: child.label,
                                         pt: {
-                                            root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] ml-3',
+                                            root: 'absolute shadow-md py-0 px-0 max-w-[260px] ml-3',
                                             text: autoDark
                                                 ? 'text-sm p-2 border border-surface-300 bg-white text-surface-700 dark:bg-surface-700 dark:border-surface-800 dark:text-white rounded-[var(--p-content-border-radius)] whitespace-pre-line'
                                                 : 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'

--- a/ui/src/components/App/Page/SideNav.vue
+++ b/ui/src/components/App/Page/SideNav.vue
@@ -93,7 +93,7 @@ const props = withDefaults(defineProps<Props>(), {
 const { items, linkComponent } = props;
 
 const tooltipPt = {
-    root: 'absolute ml-2 shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+    root: 'absolute ml-2 shadow-md py-0 px-0 max-w-[260px]',
     text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
 };
 

--- a/ui/src/components/App/Table/Actions.vue
+++ b/ui/src/components/App/Table/Actions.vue
@@ -11,7 +11,7 @@
                 v-tooltip.bottom="{
                     value: menuItem?.tooltip ?? null,
                     pt: {
-                        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] mt-1',
+                        root: 'absolute shadow-md py-0 px-0 max-w-[260px] mt-1',
                         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
                     }
                 }"
@@ -73,7 +73,7 @@
                     v-tooltip.bottom="{
                         value: 'Clear selection',
                         pt: {
-                            root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px] mt-1',
+                            root: 'absolute shadow-md py-0 px-0 max-w-[260px] mt-1',
                             text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
                         }
                     }"

--- a/ui/src/components/App/Table/Table.vue
+++ b/ui/src/components/App/Table/Table.vue
@@ -12,7 +12,7 @@
                         v-tooltip.left="{
                             value: 'Customize columns',
                             pt: {
-                                root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+                                root: 'absolute shadow-md py-0 px-0 max-w-[260px]',
                                 text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
                             }
                         }"

--- a/ui/src/components/Editor/Tools/BoldTool.vue
+++ b/ui/src/components/Editor/Tools/BoldTool.vue
@@ -28,7 +28,7 @@ const props = defineProps({
 const tooltip = {
     value: 'Bold',
     pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/BulletListTool.vue
+++ b/ui/src/components/Editor/Tools/BulletListTool.vue
@@ -26,7 +26,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Bullet list',
     pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/ClearFormattingTool.vue
+++ b/ui/src/components/Editor/Tools/ClearFormattingTool.vue
@@ -22,7 +22,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Clear formatting',
     pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/ItalicTool.vue
+++ b/ui/src/components/Editor/Tools/ItalicTool.vue
@@ -26,7 +26,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Italic',
     pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/LinkTool.vue
+++ b/ui/src/components/Editor/Tools/LinkTool.vue
@@ -78,7 +78,7 @@ const toggleLinkPopover = (event) => {
 const tooltip = {
     value: 'Add link',
     pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/OrderedListTool.vue
+++ b/ui/src/components/Editor/Tools/OrderedListTool.vue
@@ -26,7 +26,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Numbered list',
     pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };

--- a/ui/src/components/Editor/Tools/StrikeTool.vue
+++ b/ui/src/components/Editor/Tools/StrikeTool.vue
@@ -26,7 +26,7 @@ const props = defineProps({ editor: Object });
 const tooltip = {
     value: 'Strikethrough',
     pt: {
-        root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+        root: 'absolute shadow-md py-0 px-0 max-w-[260px]',
         text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
     }
 };

--- a/ui/src/components/TooltipIcon.vue
+++ b/ui/src/components/TooltipIcon.vue
@@ -39,7 +39,7 @@ const theme = computed<TooltipIconPassThroughOptions>(() => ({
 const mergedPt = computed(() => ptMerge(theme.value, props.pt));
 
 const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
-    root: 'absolute shadow-md atlas-tooltip py-0 px-0 max-w-[260px]',
+    root: 'absolute shadow-md py-0 px-0 max-w-[260px]',
     text: 'text-sm p-2 border border-surface-700 bg-surface-900 text-white dark:bg-surface-700 dark:border-surface-800 rounded-[var(--p-content-border-radius)] whitespace-pre-line'
 });
 

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -9,6 +9,7 @@
   --p-content-border-radius: var(--p-rounded-1);
 }
 
+[data-pc-name='tooltip'],
 .atlas-tooltip {
   animation: atlas-tooltip-drop 100ms cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 2100 !important;


### PR DESCRIPTION
## Summary
- set z-index for PrimeVue tooltips globally
- drop need for `atlas-tooltip` class across components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab81b3cee48325b687ba54d736432a