### PR TITLE
feat(ui): expose nav class props in app layout

### DIFF
--- a/docs/ui/application.md
+++ b/docs/ui/application.md
@@ -84,6 +84,10 @@ import { App as LayoutApp } from '@atlas/ui';
 - `widthClass: string` – max width container class. Default `'max-w-screen-2xl'`.
 - `containerClass: string` – additional classes for the main container. Default `'mx-auto p-4'`.
 - `noScroll: boolean` – disable vertical scrolling for the main content. Default `false`.
+- `sideBarBackgroundClass: string` – optional classes for the side navigation background and border. Default `''`.
+- `sideBarActiveClass: string` – class applied to active side navigation links. Default `''`.
+- `topBarBackgroundClass: string` – optional classes for the top navigation background and border. Default `''`.
+- `topBarActiveClass: string` – class applied to active top navigation links. Default `''`.
 
 ### Slots
 - `nav` – replace the navigation area entirely.

--- a/ui/src/components/App/Index.vue
+++ b/ui/src/components/App/Index.vue
@@ -12,6 +12,8 @@
                     ref="sideNavRef"
                     :items="sideBarItems"
                     :linkComponent="linkComponent"
+                    :backgroundClass="sideBarBackgroundClass"
+                    :activeClass="sideBarActiveClass"
                 >
                     <template #logo>
                         <slot name="navLogo" />
@@ -24,6 +26,8 @@
                     :items="topBarItems"
                     :linkComponent="linkComponent"
                     :widthClass="widthClass"
+                    :backgroundClass="topBarBackgroundClass"
+                    :activeClass="topBarActiveClass"
                 >
                     <template #logo>
                         <slot name="navLogo" />
@@ -139,6 +143,10 @@ interface Props {
     widthClass?: string;
     containerClass?: string;
     noScroll?: boolean;
+    sideBarBackgroundClass?: string;
+    sideBarActiveClass?: string;
+    topBarBackgroundClass?: string;
+    topBarActiveClass?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -154,6 +162,10 @@ const props = withDefaults(defineProps<Props>(), {
     widthClass: 'max-w-screen-2xl',
     containerClass: 'mx-auto p-4',
     noScroll: false,
+    sideBarBackgroundClass: '',
+    sideBarActiveClass: '',
+    topBarBackgroundClass: '',
+    topBarActiveClass: '',
 });
 
 const slots = useSlots();

--- a/ui/tests/components/AppNavClasses.test.ts
+++ b/ui/tests/components/AppNavClasses.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import App from '../../src/components/App/Index.vue';
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ url: '/' })
+}));
+
+describe('App navigation classes', () => {
+    it('passes side nav class props', () => {
+        const wrapper = mount(App, {
+            props: {
+                pageUrl: '/',
+                sideBarItems: [{ children: [{ label: 'Home', href: '/' }] }],
+                hasToast: false,
+                sideBarBackgroundClass: 'bg-red-500',
+                sideBarActiveClass: 'text-blue-500'
+            },
+            global: {
+                directives: { tooltip: vi.fn() }
+            }
+        });
+        expect(wrapper.find('div.bg-red-500').exists()).toBe(true);
+        const link = wrapper.findAll('a')[1];
+        expect(link.classes()).toContain('text-blue-500');
+    });
+
+    it('passes top nav class props', () => {
+        const wrapper = mount(App, {
+            props: {
+                pageUrl: '/',
+                isSideNav: false,
+                topBarItems: [{ label: 'Home', href: '/' }],
+                hasToast: false,
+                topBarBackgroundClass: 'bg-green-500',
+                topBarActiveClass: 'text-orange-500'
+            }
+        });
+        expect(wrapper.find('nav.bg-green-500').exists()).toBe(true);
+        const link = wrapper.findAll('a')[1];
+        expect(link.classes()).toContain('text-orange-500');
+    });
+});


### PR DESCRIPTION
## Summary
- allow custom background and active classes for default top and side navs
- document new App props
- test that nav class props are forwarded correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab876b30d08325943525ac3607b9ba