### PR TITLE
docs: update readmes for UI-only focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,17 @@
-# Atlas
+# Atlas UI
 
-Atlas is designed for apps built with [Laravel](https://laravel.com), [Vue](https://vuejs.org), and [Inertia.js](https://inertiajs.com). It bundles a Laravel backend with a library of Vue components to help teams spin up dashboards quickly. Both sides can be used together or independently.
+Atlas UI is a Vue 3 component library built with **PrimeVue 4** and **Tailwind CSS 4**. It provides reusable building blocks so teams can ship dashboards quickly in any Vue 3 application.
 
-Atlas focuses on eliminating the repeated setup that comes with every new project. It delivers guidelines and battle-tested building blocks so you can ship web-based applications faster, whether you're working on a full-blown admin system or a small dashboard.
+For backend helpers like server-driven datatable options, see the companion [Atlas Laravel](https://github.com/tmarois/atlas-laravel) package.
 
-## Laravel
+## Documentation
 
-Our Laravel package handles the backend foundation and Inertia bridge. It includes tooling for:
-
-- **DataTables** – build server-driven options for dynamic tables.
-- **Enums** – export PHP enums for type-safe usage in Vue.
-- **Model Service** – base model service providing CRUD scaffolding.
-
-**Documentation**
-
-- [Backend Guide](docs/backend-guide.md)
-- [Inertia DataTable Options](docs/laravel/inertia-data-table-options.md)
-- [Enum Exporter](docs/laravel/enum-exporter.md)
-- [Model Service](docs/laravel/model-service.md)
-- [Support](docs/laravel/support.md)
-
-## Vue
-
-The front end centers on a reusable UI library powered by **Vue 3**, **PrimeVue 4**, and **Tailwind CSS 4**. It pairs naturally with Laravel through Inertia but can also slot into any Vue 3 application.
-
-**Documentation**
-
-- [Frontend Guide](docs/frontend-guide.md)
-- [Application Layout](docs/ui/application.md)
+- [Application Layout](docs/application.md)
 - [Components](docs/ui.md)
-- [Table](docs/ui/table.md)
-- [Editor](docs/ui/editor.md)
-- [Composables](docs/ui/composables.md)
-- [Utils](docs/ui/utils.md)
+- [Table](docs/table.md)
+- [Editor](docs/editor.md)
+- [Composables](docs/composables.md)
+- [Utils](docs/utils.md)
 
 ## Contributing
 
@@ -40,13 +19,11 @@ See [AGENTS.md](AGENTS.md) for repository conventions, testing instructions, and
 
 ### Installing
 
-- Install backend dependencies with `composer install` inside `laravel/`
-- Install UI dependencies with `npm install` inside `ui/`
+- Install dependencies with `npm install`
 
 ### Testing
 
-- Run backend tests with `composer test` inside `laravel/`
-- Run UI tests with `npm test` inside `ui/`
+- Run tests with `npm test`
 
 ### Playground
 

--- a/docs/composables.md
+++ b/docs/composables.md
@@ -10,7 +10,7 @@ This documentation covers the usage of three Vue composables: `useDataTableOptio
 
 ## useDataTableOptions
 
-The `useDataTableOptions` composable keeps datatable query options in sync with the backend via Inertia. It accepts a route configuration and initial options—typically the `options` array returned by the Laravel [Inertia DataTable Options trait](../laravel/inertia-data-table-options.md)—and returns reactive refs for those options along with helpers to fetch new data.
+The `useDataTableOptions` composable keeps datatable query options in sync with the backend via Inertia. It accepts a route configuration and initial options—typically the `options` array returned by the [Atlas Laravel Inertia DataTable Options trait](https://github.com/tmarois/atlas-laravel/blob/master/docs/inertia-data-table-options.md)—and returns reactive refs for those options along with helpers to fetch new data.
 
 ### Basic Usage
 


### PR DESCRIPTION
## Summary
- rewrite main README to highlight the Vue 3 component library and link to the Atlas Laravel package for backend helpers
- fix documentation links after removing the PHP/Laravel side
- point DataTable options doc to atlas-laravel repo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68abba683a148325b96aba684de6dc16