### PR TITLE
fix: correct playground alias

### DIFF
--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -8,7 +8,10 @@ export default defineConfig({
   plugins: [vue(), tailwindcss()],
   resolve: {
     alias: {
-      '@atlas/ui': path.resolve(__dirname, '../ui/src'),
+      // Map the playground's @atlas/ui alias directly to the package source.
+      // The previous path pointed to a non-existent ../ui/src directory,
+      // breaking component imports within the playground.
+      '@atlas/ui': path.resolve(__dirname, '../src'),
       '@inertiajs/vue3': path.resolve(__dirname, './src/inertia.js')
     }
   },


### PR DESCRIPTION
## Summary
- fix playground's alias for @atlas/ui to point to local package src
- document the alias to prevent broken imports

## Testing
- `npm test`
- `npm --prefix playground run build`


------
https://chatgpt.com/codex/tasks/task_b_68abba8c491c8325b6d51a41277cd233