### PR TITLE
fix: include component styles in playground

### DIFF
--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -4,7 +4,7 @@
 
 @import "tailwindcss-primeui";
 
-@source "../../ui/src/**/*.{vue,js,ts,jsx,tsx}";
+@source "../../src/**/*.{vue,js,ts,jsx,tsx}";
 
 @plugin "@tailwindcss/typography";
 

--- a/playground/tailwind.config.js
+++ b/playground/tailwind.config.js
@@ -8,7 +8,7 @@ export default {
   content: [
       './index.html',
       './src/**/*.{vue,js,ts,jsx,tsx}',
-      '../ui/src/**/*.{vue,js,ts,jsx,tsx}',
+      '../src/**/*.{vue,js,ts,jsx,tsx}',
   ],
   plugins: [
       containerQueries,


### PR DESCRIPTION
## Summary
- scan source components for Tailwind classes in the playground
- ensure playground styles watch the correct UI source directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68abbd743e4c8325bc3cc09b42d673e3