### PR TITLE
Fix ButtonMenu closing behavior

### DIFF
--- a/src/components/ButtonMenu.vue
+++ b/src/components/ButtonMenu.vue
@@ -121,7 +121,7 @@ const onTriggerEnter = async () => {
 };
 
 const onTriggerLeave = (e: MouseEvent) => {
-    if (!isMenuOpen.value) return;
+    if (!props.onHover || !isMenuOpen.value) return;
     const toEl = e.relatedTarget as Node | null;
     if (menu.value?.$el?.contains(toEl)) return;
     closeTimeout.value = setTimeout(() => {
@@ -138,7 +138,7 @@ const onMenuShow = () => (isMenuOpen.value = true);
 const onMenuHide = () => (isMenuOpen.value = false);
 const onMenuEnter = () => clearTimeout(closeTimeout.value);
 const onMenuLeave = (e: MouseEvent) => {
-    if (!isMenuOpen.value) return;
+    if (!props.onHover || !isMenuOpen.value) return;
     const toEl = e.relatedTarget as Node | null;
     const triggerEl = getTriggerEl();
     if (triggerEl?.contains(toEl)) return;

--- a/tests/components/ButtonMenu.test.ts
+++ b/tests/components/ButtonMenu.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+import { nextTick } from 'vue';
+import ButtonMenu from '../../src/components/ButtonMenu.vue';
+
+const items = [{ label: 'Item', action: 'test' }];
+
+const ButtonStub = {
+    template: '<button @click="$emit(\'click\')"><slot /></button>',
+};
+
+const MenuStub = {
+    template:
+        '<div v-show="visible" @mouseenter="$emit(\'mouseenter\', $event)" @mouseleave="$emit(\'mouseleave\', $event)"><slot /></div>',
+    data: () => ({ visible: false }),
+    methods: {
+        show() {
+            this.visible = true;
+            this.$emit('show');
+        },
+        hide() {
+            this.visible = false;
+            this.$emit('hide');
+        },
+    },
+};
+
+const mountWithPrime = (props: any = {}) =>
+    mount(ButtonMenu, {
+        props: { items, ...props },
+        global: {
+            plugins: [PrimeVue],
+            stubs: { Button: ButtonStub, Menu: MenuStub, IconChevronDown: { template: '<span />' } },
+        },
+    });
+
+describe('ButtonMenu', () => {
+    it('keeps menu open on mouseleave when not onHover', async () => {
+        vi.useFakeTimers();
+        const wrapper = mountWithPrime();
+        await wrapper.find('button').trigger('click');
+        vi.runAllTimers();
+        await nextTick();
+        expect((wrapper.vm as any).isMenuOpen).toBe(true);
+
+        await wrapper.trigger('mouseleave', { relatedTarget: document.createElement('div') });
+        vi.runAllTimers();
+        await nextTick();
+
+        expect((wrapper.vm as any).isMenuOpen).toBe(true);
+
+        wrapper.unmount();
+        vi.useRealTimers();
+    });
+
+    it('auto closes on mouseleave when onHover', async () => {
+        vi.useFakeTimers();
+        const wrapper = mountWithPrime({ onHover: true });
+        await wrapper.trigger('mouseenter');
+        vi.runAllTimers();
+        await nextTick();
+        expect((wrapper.vm as any).isMenuOpen).toBe(true);
+
+        await wrapper.trigger('mouseleave', { relatedTarget: document.createElement('div') });
+        vi.runAllTimers();
+        await nextTick();
+
+        expect((wrapper.vm as any).isMenuOpen).toBe(false);
+
+        wrapper.unmount();
+        vi.useRealTimers();
+    });
+});


### PR DESCRIPTION
## Summary
- prevent ButtonMenu from closing on mouseleave when not using onHover
- add unit tests for ButtonMenu hover and click closing behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ace574b55483258fdbb91f8efecf47