### PR TITLE
feat: add usePrimeBindings composable

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import Button, { type ButtonPassThroughOptions, type ButtonProps } from 'primevue/button';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ ButtonProps {}
 const props = defineProps<Props>();
@@ -59,10 +60,5 @@ const theme = ref<ButtonPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
 </script>

--- a/src/components/InputText.vue
+++ b/src/components/InputText.vue
@@ -26,7 +26,8 @@
 import InputText, { type InputTextProps, type InputTextPassThroughOptions } from 'primevue/inputtext';
 import TimesIcon from '@primevue/icons/times';
 import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ InputTextProps {
     modelValue?: string;
@@ -66,12 +67,7 @@ const theme = ref<InputTextPassThroughOptions>({
         disabled:opacity-70 disabled:shadow-none disabled:placeholder:text-surface-400 disabled:dark:placeholder:text-surface-500`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, modelValue, clearable, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme, ['modelValue', 'clearable'] as const);
 const isDisabled = computed(() => !!bindProps.value.disabled);
 </script>
 

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -14,8 +14,9 @@
 
 <script setup lang="ts">
 import Menu, { type MenuPassThroughOptions, type MenuProps } from 'primevue/menu';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ MenuProps {}
 const props = defineProps<Props>();
@@ -48,12 +49,7 @@ const theme = ref<MenuPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
 
 const el = ref();
 

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,2 +1,3 @@
 export * from './useModal';
 export * from './useScroll';
+export * from './usePrimeBindings';

--- a/src/composables/usePrimeBindings.ts
+++ b/src/composables/usePrimeBindings.ts
@@ -1,0 +1,27 @@
+import { computed, unref, type Ref } from 'vue';
+import { ptMerge } from '../utils';
+
+export function usePrimeBindings<
+    P extends { pt?: Record<string, any> },
+    A extends Record<string, any>,
+    K extends keyof P = never
+>(
+    props: P,
+    attrs: A,
+    theme?: Ref<Record<string, any>> | Record<string, any>,
+    excludeKeys: ReadonlyArray<K> = []
+) {
+    const mergedPt = computed(() => ptMerge(unref(theme), props.pt));
+
+    const bindProps = computed<A & Omit<P, 'pt' | K>>(() => {
+        const { pt, ...rest } = props;
+        const clone: Record<string, any> = { ...rest };
+        excludeKeys.forEach((key) => {
+            delete clone[key as string];
+        });
+        return { ...attrs, ...clone } as A & Omit<P, 'pt' | K>;
+    });
+
+    return { bindProps, mergedPt };
+}
+


### PR DESCRIPTION
## Summary
- create reusable `usePrimeBindings` composable to merge attrs and pt options
- refactor Button, InputText and Menu components to use the new composable
- eliminate local prop casting for safer PrimeVue bindings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68acf7eb492c83258992cc499e403a2f