### PR TITLE
refactor: use usePrimeBindings across components

### DIFF
--- a/src/components/Accordion.vue
+++ b/src/components/Accordion.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import Accordion, { type AccordionPassThroughOptions, type AccordionProps } from 'primevue/accordion';
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge, ptViewMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ AccordionProps {}
 const props = defineProps<Props>();
@@ -24,10 +25,6 @@ const theme = ref<AccordionPassThroughOptions>({
     root: ``
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/AccordionContent.vue
+++ b/src/components/AccordionContent.vue
@@ -11,8 +11,9 @@
 
 <script setup lang="ts">
 import AccordionContent, { type AccordionContentPassThroughOptions, type AccordionContentProps } from 'primevue/accordioncontent';
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge, ptViewMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ AccordionContentProps {}
 const props = defineProps<Props>();
@@ -31,10 +32,6 @@ const theme = ref<AccordionContentPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/AccordionHeader.vue
+++ b/src/components/AccordionHeader.vue
@@ -17,8 +17,9 @@
 import ChevronDownIcon from '@primevue/icons/chevrondown';
 import ChevronUpIcon from '@primevue/icons/chevronup';
 import AccordionHeader, { type AccordionHeaderPassThroughOptions, type AccordionHeaderProps } from 'primevue/accordionheader';
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge, ptViewMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ AccordionHeaderProps {}
 const props = defineProps<Props>();
@@ -34,10 +35,6 @@ const theme = ref<AccordionHeaderPassThroughOptions>({
         focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-1px] focus-visible:outline-primary`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/AccordionPanel.vue
+++ b/src/components/AccordionPanel.vue
@@ -11,8 +11,9 @@
 
 <script setup lang="ts">
 import AccordionPanel, { type AccordionPanelPassThroughOptions, type AccordionPanelProps } from 'primevue/accordionpanel';
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge, ptViewMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ AccordionPanelProps {}
 const props = defineProps<Props>();
@@ -22,10 +23,6 @@ const theme = ref<AccordionPanelPassThroughOptions>({
     root: `flex flex-col border-b border-surface-200 dark:border-surface-700`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -24,7 +24,8 @@
 <script setup lang="ts">
 import { IconInfoCircleFilled, IconExclamationCircleFilled } from '@tabler/icons-vue';
 import { useAttrs, computed } from 'vue';
-import { ptMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
+
 
 interface AlertPassThroughOptions {
     root?: any;
@@ -62,11 +63,7 @@ const theme = computed<AlertPassThroughOptions>(() => ({
     actions: 'flex items-center space-x-2',
 }));
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
 
-const passThroughProps = computed(() => {
-    const { pt, warning, hideIcon, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+
 </script>

--- a/src/components/App/Topbar.vue
+++ b/src/components/App/Topbar.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
 import { computed, useAttrs } from 'vue';
-import { ptMerge } from '../../utils';
+import { usePrimeBindings } from '../../composables';
 
 interface TopbarPassThroughOptions {
     root?: any;
@@ -23,12 +23,8 @@ const theme = computed<TopbarPassThroughOptions>(() => ({
     root: 'h-[56px] bg-white border-b border-surface-300 dark:bg-surface-800 dark:border-surface-700 flex items-center w-full'
 }));
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
 
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
 
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+
 </script>

--- a/src/components/AutoComplete.vue
+++ b/src/components/AutoComplete.vue
@@ -17,8 +17,9 @@
 <script setup lang="ts">
 import ChevronDownIcon from '@primevue/icons/chevrondown';
 import AutoComplete, { type AutoCompletePassThroughOptions, type AutoCompleteProps } from 'primevue/autocomplete';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ AutoCompleteProps {}
 const props = defineProps<Props>();
@@ -108,10 +109,6 @@ const theme = ref<AutoCompletePassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import Avatar, { type AvatarPassThroughOptions, type AvatarProps } from 'primevue/avatar';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ AvatarProps {}
 const props = defineProps<Props>();
@@ -33,10 +34,6 @@ const theme = ref<AvatarPassThroughOptions>({
     image: `p-circle:rounded-full w-full h-full`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/AvatarGroup.vue
+++ b/src/components/AvatarGroup.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import AvatarGroup, { type AvatarGroupPassThroughOptions, type AvatarGroupProps } from 'primevue/avatargroup';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ AvatarGroupProps {}
 const props = defineProps<Props>();
@@ -24,10 +25,6 @@ const theme = ref<AvatarGroupPassThroughOptions>({
     root: `flex items-center *:border-2 *:border-surface-200 dark:*:border-surface-700 *:-ms-3`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import Badge, { type BadgePassThroughOptions, type BadgeProps } from 'primevue/badge';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ BadgeProps {}
 const props = defineProps<Props>();
@@ -37,10 +38,6 @@ const theme = ref<BadgePassThroughOptions>({
         p-xlarge:text-base p-xlarge:min-w-8 p-xlarge:h-8`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/ButtonGroup.vue
+++ b/src/components/ButtonGroup.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import ButtonGroup, { type ButtonGroupPassThroughOptions, type ButtonGroupProps } from 'primevue/buttongroup';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ ButtonGroupProps {}
 const props = defineProps<Props>();
@@ -27,10 +28,6 @@ const theme = ref<ButtonGroupPassThroughOptions>({
         dark:*:p-outlined:border-surface-700 dark:*:enabled:hover:p-outlined:border-surface-600 dark:*:enabled:active:p-outlined:border-surface-600`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/ButtonMenu.vue
+++ b/src/components/ButtonMenu.vue
@@ -62,12 +62,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, nextTick, useAttrs, computed } from 'vue';
+import { ref, nextTick, useAttrs } from 'vue';
 import Button from './Button.vue';
 import Menu from './Menu.vue';
 import { IconChevronDown } from '@tabler/icons-vue';
 import type { MenuItem } from 'primevue/menuitem';
-import { ptMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
+
 
 interface ButtonMenuPassThroughOptions {
     root?: any;
@@ -94,12 +95,8 @@ const theme = ref<ButtonMenuPassThroughOptions>({
     menu: {}
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, items, icon, ptData, onHover, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 
 const trigger = ref<any>(null);
 const menu = ref<any>(null);

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -14,7 +14,8 @@
 <script setup lang="ts">
 import Card, { type CardPassThroughOptions, type CardProps } from 'primevue/card';
 import { useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ CardProps {
     noPadding?: boolean;
@@ -40,10 +41,6 @@ const theme = computed<CardPassThroughOptions>(() => ({
     footer: `p-6 py-4 border-t border-surface-300 dark:border-surface-700`
 }));
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, noPadding, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Checkbox.vue
+++ b/src/components/Checkbox.vue
@@ -16,8 +16,9 @@
 import CheckIcon from '@primevue/icons/check';
 import MinusIcon from '@primevue/icons/minus';
 import Checkbox, { type CheckboxPassThroughOptions, type CheckboxProps } from 'primevue/checkbox';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ CheckboxProps {}
 const props = defineProps<Props>();
@@ -50,10 +51,6 @@ const theme = ref<CheckboxPassThroughOptions>({
         text-white p-disabled:text-surface-400 dark:p-disabled:text-surface-600`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Chip.vue
+++ b/src/components/Chip.vue
@@ -21,8 +21,9 @@
 <script setup lang="ts">
 import TimesCircleIcon from '@primevue/icons/timescircle';
 import Chip, { type ChipPassThroughOptions, type ChipProps } from 'primevue/chip';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ ChipProps {}
 const props = defineProps<Props>();
@@ -38,10 +39,6 @@ const theme = ref<ChipPassThroughOptions>({
     icon: `text-white dark:text-surface-0 text-base w-4 h-4`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -53,9 +53,10 @@ import AngleLeftIcon from '@primevue/icons/angleleft';
 import AngleRightIcon from '@primevue/icons/angleright';
 import SpinnerIcon from '@primevue/icons/spinner';
 import DataTable, { type DataTablePassThroughOptions, type DataTableProps } from 'primevue/datatable';
-import { ref, useAttrs, computed } from 'vue';
+import { ref, useAttrs } from 'vue';
 import Button from './Button.vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ DataTableProps {}
 const props = defineProps<Props>();
@@ -110,12 +111,8 @@ const theme = ref<DataTablePassThroughOptions>({
     rowReorderIndicatorDown: `absolute hidden`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 
 const el = ref();
 defineExpose({

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -100,9 +100,10 @@ import ChevronLeftIcon from '@primevue/icons/chevronleft';
 import ChevronRightIcon from '@primevue/icons/chevronright';
 import ChevronUpIcon from '@primevue/icons/chevronup';
 import DatePicker, { type DatePickerPassThroughOptions, type DatePickerProps } from 'primevue/datepicker';
-import { ref, useAttrs, computed } from 'vue';
+import { ref, useAttrs } from 'vue';
 import Button from './Button.vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ DatePickerProps {}
 const props = defineProps<Props>();
@@ -218,10 +219,6 @@ const theme = ref<DatePickerPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -31,9 +31,10 @@ import TimesIcon from '@primevue/icons/times';
 import WindowMaximizeIcon from '@primevue/icons/windowmaximize';
 import WindowMinimizeIcon from '@primevue/icons/windowminimize';
 import Dialog, { type DialogPassThroughOptions, type DialogProps } from 'primevue/dialog';
-import { ref, useAttrs, computed } from 'vue';
+import { ref, useAttrs } from 'vue';
 import Button from './Button.vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ DialogProps {}
 const props = defineProps<Props>();
@@ -59,11 +60,7 @@ const theme = ref<DialogPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>
 

--- a/src/components/DialogConfirmation.vue
+++ b/src/components/DialogConfirmation.vue
@@ -1,5 +1,6 @@
 <template>
     <Dialog
+        v-bind="dialogAttrs"
         modal
         closable
         :visible="props.modelValue"
@@ -44,7 +45,7 @@ import Button from './Button.vue';
 import { useAttrs, computed } from 'vue';
 import type { DialogProps, DialogPassThroughOptions } from 'primevue/dialog';
 import type { ButtonPassThroughOptions } from 'primevue/button';
-import { ptMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface DialogConfirmationPassThroughOptions {
     dialog?: DialogPassThroughOptions;
@@ -88,12 +89,12 @@ const theme = computed<DialogConfirmationPassThroughOptions>(() => ({
     cancelButton: {},
 }));
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-
-const passThroughProps = computed(() => {
-    const { pt, modelValue, title, icon, message, loading, ...rest } = props as any;
-    return rest;
-});
+const { bindProps: dialogAttrs, mergedPt } = usePrimeBindings(
+    props,
+    attrs,
+    theme,
+    ['modelValue', 'title', 'icon', 'message', 'loading'] as const
+);
 const close = () => emit('update:modelValue', false);
 const confirm = () => emit('confirm');
 </script>

--- a/src/components/Divider.vue
+++ b/src/components/Divider.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import Divider, { type DividerPassThroughOptions, type DividerProps } from 'primevue/divider';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ DividerProps {}
 const props = defineProps<Props>();
@@ -32,10 +33,6 @@ const theme = ref<DividerPassThroughOptions>({
         p-horizontal:py-0 p-horizontal:px-2 p-vertical:py-2 p-vertical:px-0`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -23,9 +23,10 @@
 <script setup lang="ts">
 import TimesIcon from '@primevue/icons/times';
 import Drawer, { type DrawerPassThroughOptions, type DrawerProps } from 'primevue/drawer';
-import { ref, useAttrs, computed } from 'vue';
+import { ref, useAttrs } from 'vue';
 import Button from './Button.vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ DrawerProps {}
 const props = defineProps<Props>();
@@ -54,12 +55,8 @@ const theme = ref<DrawerPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, (props as any).pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>
 
 <style>

--- a/src/components/Errors.vue
+++ b/src/components/Errors.vue
@@ -45,7 +45,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, useAttrs } from 'vue';
 import { IconAlertCircle, IconChevronDown } from '@tabler/icons-vue';
-import { isEmpty, ptMerge } from '../utils';
+import { isEmpty } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface ErrorsPassThroughOptions {
     root?: any;
@@ -97,7 +98,8 @@ const theme = ref<ErrorsPassThroughOptions>({
     defaultError: 'pl-[26px] text-left',
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 
 const hasErrors = computed(() => !isEmpty(props.errors));
 
@@ -115,12 +117,7 @@ function expandLeave(el: HTMLElement) {
     el.style.height = '0';
 }
 
-const passThroughProps = computed(() => {
-    const { pt, errors, failed, title, expandDefault, ...rest } = props as any;
-    return rest;
-});
 
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
 </script>
 
 <style scoped>

--- a/src/components/InputGroup.vue
+++ b/src/components/InputGroup.vue
@@ -11,8 +11,9 @@
 
 <script setup lang="ts">
 import InputGroup, { type InputGroupPassThroughOptions, type InputGroupProps } from 'primevue/inputgroup';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ InputGroupProps {}
 const props = defineProps<Props>();
@@ -31,10 +32,6 @@ const theme = ref<InputGroupPassThroughOptions>({
         border-surface-300 dark:border-surface-700`,
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/InputMask.vue
+++ b/src/components/InputMask.vue
@@ -9,8 +9,9 @@
 
 <script setup lang="ts">
 import InputMask, { type InputMaskPassThroughOptions, type InputMaskProps } from 'primevue/inputmask';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ InputMaskProps {}
 const props = defineProps<Props>();
@@ -35,10 +36,6 @@ const theme = ref<InputMaskPassThroughOptions>({
         transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/InputNumber.vue
+++ b/src/components/InputNumber.vue
@@ -21,8 +21,9 @@
 import AngleDownIcon from '@primevue/icons/angledown';
 import AngleUpIcon from '@primevue/icons/angleup';
 import InputNumber, { type InputNumberPassThroughOptions, type InputNumberProps } from 'primevue/inputnumber';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ InputNumberProps {}
 const props = defineProps<Props>();
@@ -83,10 +84,6 @@ const theme = ref<InputNumberPassThroughOptions>({
     decrementIcon: ``
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/InputOtp.vue
+++ b/src/components/InputOtp.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import InputOtp, { type InputOtpPassThroughOptions, type InputOtpProps } from 'primevue/inputotp';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ InputOtpProps {}
 const props = defineProps<Props>();
@@ -43,10 +44,6 @@ const theme = ref<InputOtpPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/LabelCheckbox.vue
+++ b/src/components/LabelCheckbox.vue
@@ -14,7 +14,7 @@
 <script setup lang="ts">
 import Checkbox from './Checkbox.vue';
 import { computed, useAttrs } from 'vue';
-import { ptMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface LabelCheckboxPassThroughOptions {
     root?: any;
@@ -60,10 +60,5 @@ const theme = computed<LabelCheckboxPassThroughOptions>(() => ({
     }`
 }));
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-
-const inputAttrs = computed(() => {
-    const { pt, ...rest } = attrs as any;
-    return rest;
-});
+const { bindProps: inputAttrs, mergedPt } = usePrimeBindings(props, attrs, theme, ['label'] as const);
 </script>

--- a/src/components/LabelField.vue
+++ b/src/components/LabelField.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="mergedPt.root.class">
+    <div v-bind="bindProps" :class="mergedPt.root.class">
         <label
             v-if="label"
             :for="name"
@@ -20,8 +20,8 @@
 
 <script setup lang="ts">
 import TooltipIcon from './TooltipIcon.vue';
-import { computed } from 'vue';
-import { ptMerge } from '../utils';
+import { computed, useAttrs } from 'vue';
+import { usePrimeBindings } from '../composables';
 
 interface LabelFieldPassThroughOptions {
     root?: any;
@@ -50,6 +50,8 @@ const props = withDefaults(defineProps<Props>(), {
     error: ''
 });
 
+const attrs = useAttrs();
+
 const theme = computed<LabelFieldPassThroughOptions>(() => ({
     root: 'w-full',
     label: 'flex items-center text-sm font-medium leading-6 text-gray-900 dark:text-gray-100 mb-2',
@@ -60,5 +62,5 @@ const theme = computed<LabelFieldPassThroughOptions>(() => ({
     error: 'text-sm text-red-500'
 }));
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme, ['label', 'tooltip', 'name', 'required', 'error'] as const);
 </script>

--- a/src/components/LabelRadioButton.vue
+++ b/src/components/LabelRadioButton.vue
@@ -14,7 +14,7 @@
 <script setup lang="ts">
 import RadioButton from './RadioButton.vue';
 import { computed, useAttrs } from 'vue';
-import { ptMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface LabelRadioButtonPassThroughOptions {
     root?: any;
@@ -52,10 +52,5 @@ const theme = computed<LabelRadioButtonPassThroughOptions>(() => ({
     }`
 }));
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-
-const inputAttrs = computed(() => {
-    const { pt, ...rest } = attrs as any;
-    return rest;
-});
+const { bindProps: inputAttrs, mergedPt } = usePrimeBindings(props, attrs, theme, ['label'] as const);
 </script>

--- a/src/components/MultiSelect.vue
+++ b/src/components/MultiSelect.vue
@@ -36,8 +36,9 @@ import SearchIcon from '@primevue/icons/search';
 import SpinnerIcon from '@primevue/icons/spinner';
 import TimesIcon from '@primevue/icons/times';
 import MultiSelect, { type MultiSelectPassThroughOptions, type MultiSelectProps } from 'primevue/multiselect';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 const attrs = useAttrs();
 
@@ -151,10 +152,6 @@ const theme = ref<MultiSelectPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -19,8 +19,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useAttrs, ref } from 'vue';
-import { ptMerge } from '../utils';
+import { useAttrs, ref } from 'vue';
+import { usePrimeBindings } from '../composables';
+
 
 interface PaginationLink {
     label: string;
@@ -49,10 +50,6 @@ const theme = ref<PaginationPassThroughOptions>({
     link: 'flex items-center justify-center px-3 py-2 text-sm rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700',
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, links, linkComponent, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Paginator.vue
+++ b/src/components/Paginator.vue
@@ -47,8 +47,9 @@ import AngleLeftIcon from '@primevue/icons/angleleft';
 import AngleRightIcon from '@primevue/icons/angleright';
 import Paginator, { type PaginatorPassThroughOptions, type PaginatorProps } from 'primevue/paginator';
 import Button from './Button.vue';
-import { ref, computed, useAttrs } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ PaginatorProps {}
 const props = defineProps<Props>();
@@ -59,10 +60,6 @@ const theme = ref<PaginatorPassThroughOptions>({
         bg-surface-0 dark:bg-surface-900 text-surface-700 dark:text-surface-0`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Password.vue
+++ b/src/components/Password.vue
@@ -21,8 +21,9 @@
 import EyeIcon from '@primevue/icons/eye';
 import EyeSlashIcon from '@primevue/icons/eyeslash';
 import Password, { type PasswordPassThroughOptions, type PasswordProps } from 'primevue/password';
-import { ref, computed, useAttrs } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ PasswordProps {}
 const props = defineProps<Props>();
@@ -68,10 +69,6 @@ const theme = ref<PasswordPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -14,8 +14,9 @@
 
 <script setup lang="ts">
 import Popover, { type PopoverPassThroughOptions, type PopoverProps } from 'primevue/popover';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ PopoverProps {}
 const props = defineProps<Props>();
@@ -35,12 +36,8 @@ const theme = ref<PopoverPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 
 const el = ref();
 

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import ProgressBar, { type ProgressBarPassThroughOptions, type ProgressBarProps } from 'primevue/progressbar';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ ProgressBarProps {}
 const props = defineProps<Props>();
@@ -34,12 +35,8 @@ const theme = ref<ProgressBarPassThroughOptions>({
         p-determinate:inline-flex`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, (props as any).pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>
 
 <style>

--- a/src/components/RadioButton.vue
+++ b/src/components/RadioButton.vue
@@ -9,8 +9,9 @@
 
 <script setup lang="ts">
 import RadioButton, { type RadioButtonPassThroughOptions, type RadioButtonProps } from 'primevue/radiobutton';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ RadioButtonProps {}
 const props = defineProps<Props>();
@@ -41,10 +42,6 @@ const theme = ref<RadioButtonPassThroughOptions>({
         p-disabled:bg-surface-400 dark:p-disabled:bg-surface-600`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -36,8 +36,9 @@ import SearchIcon from '@primevue/icons/search';
 import SpinnerIcon from '@primevue/icons/spinner';
 import TimesIcon from '@primevue/icons/times';
 import Select, { type SelectPassThroughOptions, type SelectProps } from 'primevue/select';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ SelectProps {}
 const props = defineProps<Props>();
@@ -112,10 +113,6 @@ const theme = ref<SelectPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Slider.vue
+++ b/src/components/Slider.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import Slider, { type SliderPassThroughOptions, type SliderProps } from 'primevue/slider';
-import { ref, computed, useAttrs } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ SliderProps {}
 const props = defineProps<Props>();
@@ -43,10 +44,6 @@ const theme = ref<SliderPassThroughOptions>({
     endHandler: handleCommon
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -11,8 +11,9 @@
 
 <script setup lang="ts">
 import Tab, { type TabPassThroughOptions, type TabProps } from 'primevue/tab';
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge, ptViewMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ TabProps {}
 const props = defineProps<Props>();
@@ -30,10 +31,6 @@ const theme = ref<TabPassThroughOptions>({
         focus-visible:z-10 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-1px] focus-visible:outline-primary`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/TabList.vue
+++ b/src/components/TabList.vue
@@ -11,8 +11,9 @@
 
 <script setup lang="ts">
 import TabList, { type TabListPassThroughOptions, type TabListProps } from 'primevue/tablist';
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge, ptViewMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ TabListProps {}
 const props = defineProps<Props>();
@@ -36,10 +37,6 @@ const theme = ref<TabListPassThroughOptions>({
     activeBar: `z-10 block absolute -bottom-px h-px bg-primary transition-[left] duration-200 ease-[cubic-bezier(0.35,0,0.25,1)]`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/TabPanel.vue
+++ b/src/components/TabPanel.vue
@@ -11,8 +11,9 @@
 
 <script setup lang="ts">
 import TabPanel, { type TabPanelPassThroughOptions, type TabPanelProps } from 'primevue/tabpanel';
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge, ptViewMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ TabPanelProps {}
 const props = defineProps<Props>();
@@ -22,10 +23,6 @@ const theme = ref<TabPanelPassThroughOptions>({
     root: ``
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/TabPanels.vue
+++ b/src/components/TabPanels.vue
@@ -11,8 +11,9 @@
 
 <script setup lang="ts">
 import TabPanels, { type TabPanelsPassThroughOptions, type TabPanelsProps } from 'primevue/tabpanels';
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge, ptViewMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ TabPanelsProps {}
 const props = defineProps<Props>();
@@ -23,10 +24,6 @@ const theme = ref<TabPanelsPassThroughOptions>({
         pt-[0.875rem] pb-[1.125rem] px-6 outline-none text-base`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import Tabs, { type TabsPassThroughOptions, type TabsProps } from 'primevue/tabs';
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge, ptViewMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ TabsProps {}
 const props = defineProps<Props>();
@@ -24,10 +25,6 @@ const theme = ref<TabsPassThroughOptions>({
     root: `flex flex-col`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Textarea.vue
+++ b/src/components/Textarea.vue
@@ -9,8 +9,9 @@
 
 <script setup lang="ts">
 import Textarea, { type TextareaPassThroughOptions, type TextareaProps } from 'primevue/textarea';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ TextareaProps {}
 const props = defineProps<Props>();
@@ -35,10 +36,6 @@ const theme = ref<TextareaPassThroughOptions>({
         transition-colors duration-200 shadow-[0_1px_2px_0_rgba(18,18,23,0.05)]`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -21,8 +21,9 @@
 import TimesIcon from '@primevue/icons/times';
 import { IconCircleCheckFilled } from '@tabler/icons-vue';
 import Toast, { type ToastPassThroughOptions, type ToastProps } from 'primevue/toast';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ ToastProps {}
 const props = defineProps<Props>();
@@ -65,10 +66,6 @@ const theme = ref<ToastPassThroughOptions>({
     }
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/ToggleButton.vue
+++ b/src/components/ToggleButton.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import ToggleButton, { type ToggleButtonPassThroughOptions, type ToggleButtonProps } from 'primevue/togglebutton';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ ToggleButtonProps {}
 const props = defineProps<Props>();
@@ -42,10 +43,6 @@ const theme = ref<ToggleButtonPassThroughOptions>({
     label: ``
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/ToggleSwitch.vue
+++ b/src/components/ToggleSwitch.vue
@@ -13,8 +13,9 @@
 
 <script setup lang="ts">
 import ToggleSwitch, { type ToggleSwitchPassThroughOptions, type ToggleSwitchProps } from 'primevue/toggleswitch';
-import { ref, useAttrs, computed } from 'vue';
-import { ptViewMerge, ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+import { ptViewMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface Props extends /* @vue-ignore */ ToggleSwitchProps {}
 const props = defineProps<Props>();
@@ -41,10 +42,6 @@ const theme = ref<ToggleSwitchPassThroughOptions>({
         p-disabled:bg-surface-700 dark:p-disabled:bg-surface-900`
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
+
 </script>

--- a/src/components/TooltipIcon.vue
+++ b/src/components/TooltipIcon.vue
@@ -1,13 +1,14 @@
 <template>
-    <span v-tooltip.top="tooltip" :class="mergedPt.root.class">
+<span v-tooltip.top="tooltip" v-bind="bindProps" :class="mergedPt.root.class">
         <IconInfoSquareRoundedFilled :class="mergedPt.icon.class" />
     </span>
 </template>
 
 <script setup lang="ts">
 import { IconInfoSquareRoundedFilled } from '@tabler/icons-vue';
-import { ref, computed } from 'vue';
+import { ref, computed, useAttrs } from 'vue';
 import { ptMerge } from '../utils';
+import { usePrimeBindings } from '../composables';
 
 interface TooltipDirectivePassThroughOptions {
     root?: any;
@@ -31,12 +32,14 @@ const props = withDefaults(defineProps<Props>(), {
     iconClass: 'size-5'
 });
 
+const attrs = useAttrs();
+
 const theme = computed<TooltipIconPassThroughOptions>(() => ({
     root: 'cursor-help inline text-surface-500 dark:text-surface-400 hover:text-surface-800 dark:hover:text-surface-300',
     icon: props.iconClass
 }));
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme, ['text', 'iconClass'] as const);
 
 const tooltipTheme = ref<TooltipDirectivePassThroughOptions>({
     root: 'absolute shadow-md py-0 px-0 max-w-[260px]',

--- a/src/components/TooltipInfo.vue
+++ b/src/components/TooltipInfo.vue
@@ -36,9 +36,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, useAttrs, computed } from 'vue';
-import { ptMerge } from '../utils';
+import { ref, useAttrs } from 'vue';
+
 import Popover from './Popover.vue';
+import { usePrimeBindings } from '../composables';
 
 interface TooltipInfoPassThroughOptions {
     root?: any;
@@ -57,13 +58,9 @@ const theme = ref<TooltipInfoPassThroughOptions>({
     icon: 'size-5'
 });
 
-const mergedPt = computed(() => ptMerge(theme.value, props.pt));
+const { bindProps, mergedPt } = usePrimeBindings(props, attrs, theme);
 
-const passThroughProps = computed(() => {
-    const { pt, ...rest } = props as any;
-    return rest;
-});
-const bindProps = computed(() => ({ ...attrs, ...passThroughProps.value }));
+
 
 const emit = defineEmits<{ (e: 'toggle', value: boolean): void }>();
 


### PR DESCRIPTION
## Summary
- refactor components to use `usePrimeBindings` for prop/attr passthrough
- streamline label and dialog helpers with `usePrimeBindings`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68acfa142c688325a7489ea1e6de950c