### PR TITLE
docs: standardize actions component guides

### DIFF
--- a/docs/ui/Button.md
+++ b/docs/ui/Button.md
@@ -1,13 +1,54 @@
 # Button
+
+Basic action trigger element.
+
 ```ts
 import { Button } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Button>Click me</Button>
 ```
 
-##### API
+## API
 
-Refer to the [PrimeVue Button API](https://primevue.org/button/#api) for available props and events.
+### Props
+| Prop | Type | Description |
+| ---- | ---- | ----------- |
+| `label` | `string` | Text of the button. |
+| `icon` | `string` | Name of the icon. |
+| `iconPos` | `'left' \| 'right' \| 'top' \| 'bottom'` | Position of the icon. Defaults to `'left'`. |
+| `iconClass` | `string \| object` | Style class of the icon. |
+| `badge` | `string` | Value of the badge. |
+| `badgeClass` | `string \| object` | Class for the badge. |
+| `badgeSeverity` | `'secondary' \| 'info' \| 'success' \| 'warn' \| 'danger' \| 'contrast'` | Severity style of the badge. |
+| `loading` | `boolean` | Displays a loading indicator. |
+| `loadingIcon` | `string` | Icon for the loading state. |
+| `as` | `string \| Component` | Tag name of the root element. Defaults to `'BUTTON'`. |
+| `asChild` | `boolean` | Use the child element as the root. |
+| `link` | `boolean` | Renders with link styling. |
+| `severity` | `'secondary' \| 'success' \| 'info' \| 'warn' \| 'help' \| 'danger' \| 'contrast'` | Visual severity. |
+| `raised` | `boolean` | Adds a box shadow. |
+| `rounded` | `boolean` | Applies rounded border radius. |
+| `text` | `boolean` | Text button without background. |
+| `outlined` | `boolean` | Bordered button without background. |
+| `size` | `'small' \| 'large'` | Button size. |
+| `variant` | `'outlined' \| 'text' \| 'link'` | Variant shorthand. |
+| `plain` | `boolean` | Plain textual button (deprecated, use `severity="contrast"`). |
+| `fluid` | `boolean` | Stretches to full width. |
+| `dt` | `DesignToken` | Design token for scoped CSS variables. |
+| `pt` | `ButtonPassThroughOptions` | Pass-through styling options. |
+| `ptOptions` | `PassThroughOptions` | Configuration for pass-through. |
+| `unstyled` | `boolean` | Removes component styles. |
 
+### Slots
+- `default` – Custom button content, overrides `label`, `icon`, and `badge`.
+- `icon` – Replaces the icon element.
+- `loadingicon` – Custom loading icon.
+
+### Events
+- None.
+
+Refer to the [PrimeVue Button API](https://primevue.org/button/#api) for full details.

--- a/docs/ui/ButtonGroup.md
+++ b/docs/ui/ButtonGroup.md
@@ -1,7 +1,12 @@
 # ButtonGroup
+
+Group multiple buttons together.
+
 ```ts
 import { ButtonGroup, Button } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <ButtonGroup>
@@ -10,8 +15,20 @@ import { ButtonGroup, Button } from '@atlas/ui';
 </ButtonGroup>
 ```
 
-##### API
+## API
 
-Refer to the [PrimeVue ButtonGroup API](https://primevue.org/buttongroup/#api).
+### Props
+| Prop | Type | Description |
+| ---- | ---- | ----------- |
+| `dt` | `DesignToken` | Design token for scoped CSS variables. |
+| `pt` | `ButtonGroupPassThroughOptions` | Pass-through styling options. |
+| `ptOptions` | `PassThroughOptions` | Configuration for pass-through. |
+| `unstyled` | `boolean` | Removes component styles. |
 
+### Slots
+- `default` – Buttons to display in the group.
 
+### Events
+- None.
+
+Refer to the [PrimeVue ButtonGroup API](https://primevue.org/buttongroup/#api) for full details.

--- a/docs/ui/ButtonMenu.md
+++ b/docs/ui/ButtonMenu.md
@@ -1,24 +1,32 @@
 # ButtonMenu
+
+Dropdown menu activated from a button.
+
 ```ts
 import { ButtonMenu } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <ButtonMenu :items="items" @action="onAction" />
 ```
 
-##### Props
+## API
 
-- `items` – array of menu item objects.
-- `icon` – icon class for the default trigger. Defaults to `'pi pi-ellipsis-v'`.
-- `ptData` – additional data passed with the `action` event.
-- `onHover` – show menu on hover instead of click.
+### Props
+| Prop | Type | Description |
+| ---- | ---- | ----------- |
+| `items` | `MenuItem[]` | Menu items with `label`, `icon`, `action`, `disabled`, optional `children` for submenus, and `tooltip`. |
+| `icon` | `string` | Icon class for the default trigger. Defaults to `'pi pi-ellipsis-v'`. |
+| `ptData` | `Record<string, any>` | Additional data forwarded with the `action` event. |
+| `onHover` | `boolean` | Show menu on hover instead of click. Defaults to `false`. |
+| `pt` | `ButtonMenuPassThroughOptions` | Pass-through styling options. |
+ 
+### Slots
+- `trigger` – Custom trigger element. Slot props: `{ toggleMenu, triggerRef }`.
 
-##### Slots
+### Events
+- `action` – Emitted when an item is selected. Arguments: `(action: any, ptData: Record<string, any>)`.
 
-- `trigger` – custom trigger element. Receives `{ toggleMenu, triggerRef }`.
-
-##### Events
-
-- `action` – emitted when an item is selected. Arguments: `(action, ptData)`.
-
+Refer to the [PrimeVue Menu API](https://primevue.org/menu/#api) for menu item options.

--- a/docs/ui/TableActions.md
+++ b/docs/ui/TableActions.md
@@ -1,18 +1,29 @@
 # TableActions
+
+Toolbar for batch table actions.
+
 ```ts
 import { TableActions } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <TableActions :selectedCount="selected.length" :menuItems="actions" @action="onAction" />
 ```
 
-##### Props
+## API
 
-- `selectedCount: number` – number of selected rows.
-- `menuItems: any[]` – action definitions. Child items may provide nested menus.
+### Props
+| Prop | Type | Description |
+| ---- | ---- | ----------- |
+| `selectedCount` | `number` | Number of selected rows. Displayed next to actions. |
+| `menuItems` | `MenuItem[]` | Action definitions. Each item supports `label`, `action`, optional `tooltip`, `disabled`, and nested `children` arrays for submenus. |
 
-##### Events
+### Slots
+- None.
 
-- `action` – emitted with the action identifier. `'clear'` is emitted when the clear button is pressed.
+### Events
+- `action` – Emitted when an action is chosen. Arguments: `(action: string)`; `'clear'` is emitted when the clear button is pressed.
 
+Refer to the [PrimeVue Menu API](https://primevue.org/menu/#api) for menu item options.


### PR DESCRIPTION
## Summary
- expand Button and ButtonGroup docs with explicit props, slots, and events
- clarify ButtonMenu and TableActions API details and drop redundant import headers
- format Button, ButtonGroup, ButtonMenu, and TableActions prop lists as tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68acfcdaef308325b991c34a6736c68d