### PR TITLE
docs: add missing component guides

### DIFF
--- a/docs/ui/AccordionContent.md
+++ b/docs/ui/AccordionContent.md
@@ -1,0 +1,36 @@
+# AccordionContent
+
+Content section of an accordion panel.
+
+```ts
+import { AccordionContent } from '@atlas/ui';
+```
+
+## Usage
+
+```vue
+<Accordion>
+  <AccordionPanel value="0">
+    <AccordionHeader>Header</AccordionHeader>
+    <AccordionContent>Content</AccordionContent>
+  </AccordionPanel>
+</Accordion>
+```
+
+## API
+
+### Props
+
+None.
+
+### Slots
+
+| Name | Description |
+| ---- | ----------- |
+| `default` | Content of the accordion panel. |
+
+### Events
+
+None.
+
+Refer to the [PrimeVue Accordion API](https://primevue.org/accordion/#api).

--- a/docs/ui/AccordionHeader.md
+++ b/docs/ui/AccordionHeader.md
@@ -1,0 +1,37 @@
+# AccordionHeader
+
+Toggle control for an accordion panel.
+
+```ts
+import { AccordionHeader } from '@atlas/ui';
+```
+
+## Usage
+
+```vue
+<Accordion>
+  <AccordionPanel value="0">
+    <AccordionHeader>Header</AccordionHeader>
+    <AccordionContent>Content</AccordionContent>
+  </AccordionPanel>
+</Accordion>
+```
+
+## API
+
+### Props
+
+None.
+
+### Slots
+
+| Name | Description |
+| ---- | ----------- |
+| `default` | Label of the accordion section. |
+| `toggleicon` | Custom toggle icon when expanding or collapsing. |
+
+### Events
+
+None.
+
+Refer to the [PrimeVue Accordion API](https://primevue.org/accordion/#api).

--- a/docs/ui/AccordionPanel.md
+++ b/docs/ui/AccordionPanel.md
@@ -1,0 +1,44 @@
+# AccordionPanel
+
+Wrapper for a single accordion section.
+
+```ts
+import { AccordionPanel } from '@atlas/ui';
+```
+
+## Usage
+
+```vue
+<Accordion>
+  <AccordionPanel value="0">
+    <AccordionHeader>Header</AccordionHeader>
+    <AccordionContent>Content</AccordionContent>
+  </AccordionPanel>
+</Accordion>
+```
+
+## API
+
+### Props
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `value` | `string \| number` | — | Unique identifier for the panel. |
+| `disabled` | `boolean` | `false` | Disables user interaction. |
+| `as` | `string \| Component` | `div` | Tag name of the root element. |
+| `asChild` | `boolean` | `false` | Use the child element as the root. |
+| `dt` | `DesignToken` | — | Design token for scoped CSS variables. |
+| `pt` | `AccordionPanelPassThroughOptions` | — | Pass-through styling options. |
+| `ptOptions` | `PassThroughOptions` | — | Configuration for pass-through options. |
+
+### Slots
+
+| Name | Description |
+| ---- | ----------- |
+| `default` | Content of the accordion panel. |
+
+### Events
+
+None.
+
+Refer to the [PrimeVue Accordion API](https://primevue.org/accordion/#api).

--- a/docs/ui/Tab.md
+++ b/docs/ui/Tab.md
@@ -1,0 +1,43 @@
+# Tab
+
+Individual tab header within a tab set.
+
+```ts
+import { Tab } from '@atlas/ui';
+```
+
+## Usage
+
+```vue
+<Tabs value="0">
+  <TabList>
+    <Tab value="0">One</Tab>
+  </TabList>
+</Tabs>
+```
+
+## API
+
+### Props
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `value` | `string \| number` | — | Unique identifier of the tab. |
+| `disabled` | `boolean` | `false` | Disables user interaction. |
+| `as` | `string \| Component` | `button` | Tag name of the root element. |
+| `asChild` | `boolean` | `false` | Use the child element as the root. |
+| `dt` | `DesignToken` | — | Design token for scoped CSS variables. |
+| `pt` | `TabPassThroughOptions` | — | Pass-through styling options. |
+| `ptOptions` | `PassThroughOptions` | — | Configuration for pass-through options. |
+
+### Slots
+
+| Name | Description |
+| ---- | ----------- |
+| `default` | Content of the tab header. |
+
+### Events
+
+None.
+
+Refer to the [PrimeVue Tabs API](https://primevue.org/tabs/#api).

--- a/docs/ui/TabList.md
+++ b/docs/ui/TabList.md
@@ -1,0 +1,40 @@
+# TabList
+
+Container for tab headers.
+
+```ts
+import { TabList } from '@atlas/ui';
+```
+
+## Usage
+
+```vue
+<Tabs value="0">
+  <TabList>
+    <Tab value="0">One</Tab>
+    <Tab value="1">Two</Tab>
+  </TabList>
+</Tabs>
+```
+
+## API
+
+### Props
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `dt` | `DesignToken` | — | Design token for scoped CSS variables. |
+| `pt` | `TabListPassThroughOptions` | — | Pass-through styling options. |
+| `ptOptions` | `PassThroughOptions` | — | Configuration for pass-through options. |
+
+### Slots
+
+| Name | Description |
+| ---- | ----------- |
+| `default` | Tab headers to display. |
+
+### Events
+
+None.
+
+Refer to the [PrimeVue Tabs API](https://primevue.org/tabs/#api).

--- a/docs/ui/TabPanel.md
+++ b/docs/ui/TabPanel.md
@@ -1,0 +1,42 @@
+# TabPanel
+
+Content container for a tab.
+
+```ts
+import { TabPanel } from '@atlas/ui';
+```
+
+## Usage
+
+```vue
+<Tabs value="0">
+  <TabPanels>
+    <TabPanel value="0">Content</TabPanel>
+  </TabPanels>
+</Tabs>
+```
+
+## API
+
+### Props
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `value` | `string \| number` | — | Unique identifier of the panel. |
+| `as` | `string \| Component` | `div` | Tag name of the root element. |
+| `asChild` | `boolean` | `false` | Use the child element as the root. |
+| `dt` | `DesignToken` | — | Design token for scoped CSS variables. |
+| `pt` | `TabPanelPassThroughOptions` | — | Pass-through styling options. |
+| `ptOptions` | `PassThroughOptions` | — | Configuration for pass-through options. |
+
+### Slots
+
+| Name | Description |
+| ---- | ----------- |
+| `default` | Content of the tab panel. |
+
+### Events
+
+None.
+
+Refer to the [PrimeVue Tabs API](https://primevue.org/tabs/#api).

--- a/docs/ui/TabPanels.md
+++ b/docs/ui/TabPanels.md
@@ -1,0 +1,40 @@
+# TabPanels
+
+Wrapper for multiple tab panels.
+
+```ts
+import { TabPanels } from '@atlas/ui';
+```
+
+## Usage
+
+```vue
+<Tabs value="0">
+  <TabPanels>
+    <TabPanel value="0">Content 1</TabPanel>
+    <TabPanel value="1">Content 2</TabPanel>
+  </TabPanels>
+</Tabs>
+```
+
+## API
+
+### Props
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `dt` | `DesignToken` | — | Design token for scoped CSS variables. |
+| `pt` | `TabPanelsPassThroughOptions` | — | Pass-through styling options. |
+| `ptOptions` | `PassThroughOptions` | — | Configuration for pass-through options. |
+
+### Slots
+
+| Name | Description |
+| ---- | ----------- |
+| `default` | Tab panels to display. |
+
+### Events
+
+None.
+
+Refer to the [PrimeVue Tabs API](https://primevue.org/tabs/#api).


### PR DESCRIPTION
## Summary
- document AccordionContent, AccordionHeader, and AccordionPanel components
- document Tab, TabList, TabPanel, and TabPanels components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ad0412cda883259611060a0e7ced91