### PR TITLE
docs: rename components guide and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ For backend helpers like server-driven datatable options, see the companion [Atl
 
 ## Documentation
 
-- [Application Layout](docs/application.md)
-- [Components](docs/ui.md)
-- [Table](docs/table.md)
-- [Editor](docs/editor.md)
+- [Application components](docs/application.md)
+- [Components](docs/components.md)
 - [Composables](docs/composables.md)
 - [Utils](docs/utils.md)
 

--- a/docs/application.md
+++ b/docs/application.md
@@ -1,4 +1,4 @@
-# Application Layout
+# Application components
 
 Composes navigation, page chrome, and page content into a full application wrapper.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -2,7 +2,7 @@
 
 Reusable Vue 3 components built on PrimeVue.
 
-See [Application](application.md) for layout guidance and [Theming](theming.md) for customization options.
+See [Application components](application.md) for layout guidance and [Theming](theming.md) for customization options.
 
 ## Components
 


### PR DESCRIPTION
## Summary
- rename docs/ui.md to docs/components.md and update README link
- remove table and editor docs from README
- retitle application documentation to application components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ad045bc23c832599e8a092be0777d8