### PR TITLE
docs: standardize layout component guides

### DIFF
--- a/docs/ui/Accordion.md
+++ b/docs/ui/Accordion.md
@@ -1,7 +1,12 @@
 # Accordion
+
+Collapsible panels for organizing content.
+
 ```ts
 import { Accordion, AccordionPanel, AccordionHeader, AccordionContent } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Accordion>
@@ -12,7 +17,13 @@ import { Accordion, AccordionPanel, AccordionHeader, AccordionContent } from '@a
 </Accordion>
 ```
 
-##### API
+## API
 
-Refer to the [PrimeVue Accordion API](https://primevue.org/accordion/#api).
+### Props
+See the [PrimeVue Accordion API](https://primevue.org/accordion/#api) for a full list of props.
 
+### Slots
+See the [PrimeVue Accordion API](https://primevue.org/accordion/#api) for available slots.
+
+### Events
+See the [PrimeVue Accordion API](https://primevue.org/accordion/#api) for emitted events.

--- a/docs/ui/Card.md
+++ b/docs/ui/Card.md
@@ -1,17 +1,26 @@
 # Card
+
+Container for grouping related content.
+
 ```ts
 import { Card } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Card title="Title">Content</Card>
 ```
 
-##### Props
+## API
 
-- `noPadding` – removes padding from the card's content section.
+### Props
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `noPadding` | `boolean` | `false` | Removes padding from the card's content section. |
 
-##### API
+### Slots
+See the [PrimeVue Card API](https://primevue.org/card/#api) for available slots.
 
-Refer to the [PrimeVue Card API](https://primevue.org/card/#api).
-
+### Events
+See the [PrimeVue Card API](https://primevue.org/card/#api) for emitted events.

--- a/docs/ui/Dialog.md
+++ b/docs/ui/Dialog.md
@@ -1,7 +1,12 @@
 # Dialog
+
+Modal overlay for user interactions.
+
 ```ts
 import { Dialog, Button } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Dialog v-model:visible="visible">
@@ -12,7 +17,13 @@ import { Dialog, Button } from '@atlas/ui';
 </Dialog>
 ```
 
-##### API
+## API
 
-Refer to the [PrimeVue Dialog API](https://primevue.org/dialog/#api).
+### Props
+See the [PrimeVue Dialog API](https://primevue.org/dialog/#api) for a full list of props.
 
+### Slots
+See the [PrimeVue Dialog API](https://primevue.org/dialog/#api) for available slots.
+
+### Events
+See the [PrimeVue Dialog API](https://primevue.org/dialog/#api) for emitted events.

--- a/docs/ui/DialogConfirmation.md
+++ b/docs/ui/DialogConfirmation.md
@@ -1,23 +1,33 @@
 # DialogConfirmation
+
+Preconfigured dialog for confirming destructive actions.
+
 ```ts
 import { DialogConfirmation } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <DialogConfirmation v-model="open" title="Delete item" @confirm="remove" />
 ```
 
-##### Props
+## API
 
-- `modelValue: boolean` – controls visibility.
-- `title: string` – header text. Default `'Delete Item'`.
-- `icon: string` – icon class for the dialog. Default `'pi pi-trash'`.
-- `message: string` – confirmation message.
-- `loading: boolean` – disable buttons and show loading state.
-- `pt: object` – passthrough options for internal elements.
+### Props
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `boolean` | `false` | Controls visibility. |
+| `title` | `string` | `'Delete Item'` | Header text. |
+| `icon` | `string` | `'pi pi-trash'` | Icon class for the dialog. |
+| `message` | `string` | `'Are you sure you want to delete this item?'` | Confirmation message. |
+| `loading` | `boolean` | `false` | Disables buttons and shows loading state. |
+| `pt` | `DialogConfirmationPassThroughOptions` | `undefined` | Passthrough options for internal elements. |
 
-##### Events
+### Slots
+- `message` – custom confirmation message and icon.
+- `actions` – replace the default action buttons.
 
+### Events
 - `update:modelValue` – emitted when visibility changes.
-- `confirm` – emitted when the confirm button is clicked.
-
+- `confirm` – emitted when the confirm action is triggered.

--- a/docs/ui/Divider.md
+++ b/docs/ui/Divider.md
@@ -1,13 +1,24 @@
 # Divider
+
+Visual separator for content sections.
+
 ```ts
 import { Divider } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Divider />
 ```
 
-##### API
+## API
 
-Refer to the [PrimeVue Divider API](https://primevue.org/divider/#api).
+### Props
+See the [PrimeVue Divider API](https://primevue.org/divider/#api) for a full list of props.
 
+### Slots
+See the [PrimeVue Divider API](https://primevue.org/divider/#api) for available slots.
+
+### Events
+See the [PrimeVue Divider API](https://primevue.org/divider/#api) for emitted events.

--- a/docs/ui/Drawer.md
+++ b/docs/ui/Drawer.md
@@ -1,7 +1,12 @@
 # Drawer
+
+Panel that slides in from the edge of the screen.
+
 ```ts
 import { Drawer } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Drawer v-model:visible="visible">
@@ -9,7 +14,13 @@ import { Drawer } from '@atlas/ui';
 </Drawer>
 ```
 
-##### API
+## API
 
-Refer to the [PrimeVue Drawer API](https://primevue.org/drawer/#api).
+### Props
+See the [PrimeVue Drawer API](https://primevue.org/drawer/#api) for a full list of props.
 
+### Slots
+See the [PrimeVue Drawer API](https://primevue.org/drawer/#api) for available slots.
+
+### Events
+See the [PrimeVue Drawer API](https://primevue.org/drawer/#api) for emitted events.

--- a/docs/ui/DrawerForm.md
+++ b/docs/ui/DrawerForm.md
@@ -1,7 +1,12 @@
 # DrawerForm
+
+Form container presented inside a sliding drawer.
+
 ```ts
 import { DrawerForm } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <DrawerForm v-model="open" title="Title" @submit="save">
@@ -9,22 +14,28 @@ import { DrawerForm } from '@atlas/ui';
 </DrawerForm>
 ```
 
-##### Props
+## API
 
-- `modelValue` – controls visibility.
-- `title` – header text.
-- `loading` – shows loading state on save.
-- `width` – optional width of drawer.
-- `errors` – form error object.
-- `tabs` – array of tab definitions.
-  - `title: string`
-  - `disabled?: boolean`
-  - `lockTooltipText?: string` – when `disabled`, display a lock icon with this tooltip.
-- `modelActiveTab` – active tab index.
+### Props
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `boolean` | `false` | Controls visibility. |
+| `title` | `string` | `''` | Drawer title text. |
+| `loading` | `boolean` | `false` | Shows loading state on save. |
+| `width` | `string` | `undefined` | Optional width of the drawer. |
+| `errors` | `Record<string, any>` | `undefined` | Form error object. |
+| `tabs` | `Tab[]` | `[]` | Array of tab definitions `{ title, disabled?, lockTooltipText? }`. |
+| `modelActiveTab` | `number` | `0` | Index of the active tab. |
 
-##### Events
+### Slots
+- `header` – custom header content.
+- `default` – form content or first tab panel.
+- `tab-{index}` – content for the tab at the specified index.
+- `footer` – custom footer content.
+- `message` – message above footer actions.
+- `actions` – replace default footer actions.
 
+### Events
 - `update:modelValue` – emitted when visibility changes.
-- `submit` – emitted on save.
+- `submit` – emitted when the save action is triggered.
 - `update:modelActiveTab` – emitted when active tab changes.
-

--- a/docs/ui/Popover.md
+++ b/docs/ui/Popover.md
@@ -1,7 +1,12 @@
 # Popover
+
+Transient overlay for supplemental content.
+
 ```ts
 import { Popover, Button } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Popover ref="popover">
@@ -10,7 +15,13 @@ import { Popover, Button } from '@atlas/ui';
 <Button label="Show" @click="popover.toggle($event)" />
 ```
 
-##### API
+## API
 
-Refer to the [PrimeVue Popover API](https://primevue.org/popover/#api).
+### Props
+See the [PrimeVue Popover API](https://primevue.org/popover/#api) for a full list of props.
 
+### Slots
+See the [PrimeVue Popover API](https://primevue.org/popover/#api) for available slots.
+
+### Events
+See the [PrimeVue Popover API](https://primevue.org/popover/#api) for emitted events.

--- a/docs/ui/ScrollFrame.md
+++ b/docs/ui/ScrollFrame.md
@@ -1,7 +1,12 @@
 # ScrollFrame
+
+Provides a scrollable container sized to the viewport. When `page` is set it locks body scrolling and uses `scroll-key` to preserve position.
+
 ```ts
 import { ScrollFrame } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <ScrollFrame
@@ -14,14 +19,20 @@ import { ScrollFrame } from '@atlas/ui';
 </ScrollFrame>
 ```
 
-Provides a scrollable container sized to the viewport. When `page` is set it locks body scrolling and uses `scroll-key` to preserve position.
+## API
 
-##### Props
+### Props
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `scrollKey` | `string \| null` | `null` | Identifier used to persist scroll position. |
+| `page` | `boolean` | `false` | Lock body scroll and treat the frame as a full page. |
+| `allowBodyScroll` | `boolean` | `false` | Allow body scroll even when `page` is `true`. |
+| `offset` | `number \| null` | `null` | Explicit pixel offset for height calculation. |
+| `addOffset` | `number` | `0` | Extra pixels subtracted from height. |
+| `rootClass` | `string` | `overflow-y-auto` | Additional classes for the frame element. |
 
-- `scrollKey` (string | null) – identifier used by the scroll composable to persist position. Defaults to `null`.
-- `page` (boolean) – lock body scroll and treat the frame as a full page. Defaults to `false`.
-- `allowBodyScroll` (boolean) – allow body scroll even when `page` is `true`. Defaults to `false`.
-- `offset` (number | null) – explicit pixel offset for height calculation. Defaults to element top position.
-- `addOffset` (number) – extra pixels subtracted from height. Defaults to `0`.
-- `rootClass` (string) – additional classes for the frame element. Defaults to `overflow-y-auto`.
+### Slots
+- `default` – scrollable content.
 
+### Events
+- None.

--- a/docs/ui/Tabs.md
+++ b/docs/ui/Tabs.md
@@ -1,7 +1,12 @@
 # Tabs
+
+Container for managing multiple tabbed panels.
+
 ```ts
 import { Tabs, Tab, TabList, TabPanel, TabPanels } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Tabs value="0">
@@ -16,8 +21,13 @@ import { Tabs, Tab, TabList, TabPanel, TabPanels } from '@atlas/ui';
 </Tabs>
 ```
 
-##### API
+## API
 
-Refer to the [PrimeVue Tabs API](https://primevue.org/tabs/#api).
+### Props
+See the [PrimeVue Tabs API](https://primevue.org/tabs/#api) for a full list of props.
 
+### Slots
+See the [PrimeVue Tabs API](https://primevue.org/tabs/#api) for available slots.
 
+### Events
+See the [PrimeVue Tabs API](https://primevue.org/tabs/#api) for emitted events.

--- a/docs/ui/Topbar.md
+++ b/docs/ui/Topbar.md
@@ -1,7 +1,12 @@
 # Topbar
+
+Simple bar displayed above page content.
+
 ```ts
 import { Topbar } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Topbar>
@@ -9,15 +14,15 @@ import { Topbar } from '@atlas/ui';
 </Topbar>
 ```
 
-##### Props
+## API
 
-- `pt: object` – passthrough options for internal elements.
+### Props
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `pt` | `TopbarPassThroughOptions` | `undefined` | Passthrough options for internal elements. |
 
-##### Slots
+### Slots
+- `default` – bar content.
 
-- `default` – content rendered inside the bar.
-
-##### Events
-
-- None
-
+### Events
+- None.


### PR DESCRIPTION
## Summary
- restructured layout component docs to follow current guidelines with usage and API sections
- documented custom props, slots, and events for components like ScrollFrame and DialogConfirmation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ad0732a4508325801942319bb24faa