### PR TITLE
docs: align data display component docs

### DIFF
--- a/docs/ui/Avatar.md
+++ b/docs/ui/Avatar.md
@@ -1,13 +1,29 @@
 # Avatar
+
+Avatar displays an image, icon, or initials representing a user or entity.
+
 ```ts
 import { Avatar } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Avatar label="AB" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue Avatar API](https://primevue.org/avatar/#api).
-

--- a/docs/ui/AvatarGroup.md
+++ b/docs/ui/AvatarGroup.md
@@ -1,7 +1,12 @@
 # AvatarGroup
+
+AvatarGroup stacks multiple Avatars together.
+
 ```ts
 import { AvatarGroup, Avatar } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <AvatarGroup>
@@ -10,7 +15,18 @@ import { AvatarGroup, Avatar } from '@atlas/ui';
 </AvatarGroup>
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue AvatarGroup API](https://primevue.org/avatargroup/#api).
-

--- a/docs/ui/Chip.md
+++ b/docs/ui/Chip.md
@@ -1,13 +1,29 @@
 # Chip
+
+Chip is a compact element representing an input, attribute, or action.
+
 ```ts
 import { Chip } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Chip label="Label" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue Chip API](https://primevue.org/chip/#api).
-

--- a/docs/ui/DataTable.md
+++ b/docs/ui/DataTable.md
@@ -1,8 +1,13 @@
 # DataTable
+
+DataTable displays tabular data with optional pagination and sorting.
+
 ```ts
 import { DataTable } from '@atlas/ui';
 import Column from 'primevue/column';
 ```
+
+## Usage
 
 ```vue
 <DataTable :value="rows">
@@ -11,8 +16,18 @@ import Column from 'primevue/column';
 </DataTable>
 ```
 
-##### API
+## API
 
-Refer to the [PrimeVue DataTable API](https://primevue.org/datatable/#api).
-See the [Table guide](../table.md) for column definitions, pagination, and CSV export.
+### Props
 
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
+
+Refer to the [PrimeVue DataTable API](https://primevue.org/datatable/#api). See the [Table guide](../table.md) for column definitions, pagination, and CSV export.

--- a/docs/ui/EditorContent.md
+++ b/docs/ui/EditorContent.md
@@ -1,14 +1,31 @@
 # EditorContent
+
+EditorContent renders read-only HTML produced by the Editor.
+
 ```ts
 import { EditorContent } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <EditorContent :content="html" />
 ```
 
-##### Props
+## API
 
-- `content: string` – HTML string to render.
+### Props
 
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| content | `string` | — | HTML string to render. |
 
+### Slots
+
+None.
+
+### Events
+
+None.
+
+Refer to the [Tiptap EditorContent documentation](https://tiptap.dev/docs/editor/api/editor-content).

--- a/docs/ui/Table.md
+++ b/docs/ui/Table.md
@@ -1,7 +1,12 @@
 # Table
+
+Table is a wrapper around DataTable with column configuration and selection features.
+
 ```ts
 import { Table } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Table
@@ -12,36 +17,43 @@ import { Table } from '@atlas/ui';
 />
 ```
 
-##### Props
+## API
 
-- `items: any[]` – table data rows.
-- `itemTotal: number` – total item count.
-- `selected: any[]` – selected rows.
-- `selectAll: boolean` – select all across pages.
-- `columns: any[]` – column definitions.
-- `activeColumnList: any[]` – ordered list of visible column keys.
-- `defaultColumnList: any[]` – default column keys.
-- `size: string` – table size, default `'small'`.
-- `tableStyle: string` – inline style for table width.
-- `dataKey: string` – unique key field, default `'id'`.
-- `emptyLabel: string` – message when no data, default `'No results'`.
-- `hasSelectAll: boolean` – show select-all menu.
-- `hasSelection: boolean` – enable row selection.
-- `hasCustomizeColumns: boolean` – enable column customization UI.
-- `scrollOffset: number` – additional offset for the scroll frame.
-- `scrollable: boolean` – enable DataTable scrolling.
+### Props
 
-##### Events
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| items | `any[]` | — | Table data rows. |
+| itemTotal | `number` | `0` | Total number of items. |
+| selected | `any[]` | `undefined` | Selected rows. |
+| selectAll | `boolean` | `false` | Select all rows across pages. |
+| columns | `any[]` | — | Column definitions. |
+| activeColumnList | `any[]` | — | Ordered list of visible column keys. |
+| defaultColumnList | `any[]` | `[]` | Default column keys. |
+| size | `string` | `'small'` | Table size. |
+| tableStyle | `string` | `'min-width: 50rem'` | Inline style for the table element. |
+| dataKey | `string` | `'id'` | Unique field for row keys. |
+| emptyLabel | `string` | `'No results'` | Message when no data is available. |
+| hasSelectAll | `boolean` | `true` | Show select-all menu. |
+| hasSelection | `boolean` | `false` | Enable row selection. |
+| hasCustomizeColumns | `boolean` | `false` | Enable column customization UI. |
+| scrollOffset | `number` | `0` | Additional offset for the scroll frame. |
+| scrollable | `boolean` | `false` | Enable DataTable scrolling. |
 
-- `sort` – emitted with `{ field, order }` when sorting changes.
-- `update:selected` – emitted with selected rows.
-- `update:selectAll` – emitted when the select-all state changes.
-- `update:activeColumnList` – emitted with new active column keys.
+### Slots
 
-##### Slots
+| Name | Description |
+| ---- | ----------- |
+| columnKey | Named slots for custom cell templates using the column key. |
+| empty | Content shown when no rows exist. |
 
-- `columnKey` – named slots for custom cell templates using the column key.
-- `empty` – content shown when no rows exist.
+### Events
 
-Built on PrimeVue's DataTable. See the [DataTable API](https://primevue.org/datatable/#api) for additional options.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| sort | `{ field: string; order: number }` | Emitted when sorting changes. |
+| update:selected | `any[]` | Emitted with selected rows. |
+| update:selectAll | `boolean` | Emitted when the select-all state changes. |
+| update:activeColumnList | `string[]` | Emitted with new active column keys. |
 
+Built on PrimeVue's DataTable. Refer to the [PrimeVue DataTable API](https://primevue.org/datatable/#api).

--- a/docs/ui/TableActions.md
+++ b/docs/ui/TableActions.md
@@ -15,15 +15,20 @@ import { TableActions } from '@atlas/ui';
 ## API
 
 ### Props
-| Prop | Type | Description |
-| ---- | ---- | ----------- |
-| `selectedCount` | `number` | Number of selected rows. Displayed next to actions. |
-| `menuItems` | `MenuItem[]` | Action definitions. Each item supports `label`, `action`, optional `tooltip`, `disabled`, and nested `children` arrays for submenus. |
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| selectedCount | `number \| null` | `null` | Number of selected rows displayed next to actions. |
+| menuItems | `MenuItem[]` | `[]` | Action definitions. Each item supports `label`, `action`, optional `tooltip`, `disabled`, and nested `children` arrays for submenus. |
 
 ### Slots
-- None.
+
+None.
 
 ### Events
-- `action` – Emitted when an action is chosen. Arguments: `(action: string)`; `'clear'` is emitted when the clear button is pressed.
+
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| action | `string` | Emitted when an action is chosen. `'clear'` is emitted when the clear button is pressed. |
 
 Refer to the [PrimeVue Menu API](https://primevue.org/menu/#api) for menu item options.

--- a/docs/ui/TableCustomizeColumns.md
+++ b/docs/ui/TableCustomizeColumns.md
@@ -1,7 +1,12 @@
 # TableCustomizeColumns
+
+TableCustomizeColumns displays a popover to show and reorder table columns.
+
 ```ts
 import { TableCustomizeColumns } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <TableCustomizeColumns
@@ -16,17 +21,26 @@ import { TableCustomizeColumns } from '@atlas/ui';
 </TableCustomizeColumns>
 ```
 
-##### Props
+## API
 
-- `columns: any[]` – column definitions.
-- `activeColumnList: any[]` – visible column keys.
-- `defaultColumnList: any[]` – default visible column keys.
+### Props
 
-##### Events
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| columns | `any[]` | — | Column definitions. |
+| activeColumnList | `any[]` | — | Visible column keys. |
+| defaultColumnList | `any[]` | — | Default visible column keys. |
 
-- `update` – emitted with new array of active column keys.
+### Slots
 
-##### Slots
+| Name | Description |
+| ---- | ----------- |
+| trigger | Custom element that toggles the popover. |
 
-- `trigger` – custom element that toggles the popover.
+### Events
 
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| update | `string[]` | Emitted with new array of active column keys. |
+
+Refer to the [PrimeVue Popover API](https://primevue.org/popover/#api).

--- a/docs/ui/TooltipIcon.md
+++ b/docs/ui/TooltipIcon.md
@@ -1,15 +1,33 @@
 # TooltipIcon
+
+TooltipIcon displays an informational icon with a tooltip.
+
 ```ts
 import { TooltipIcon } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <TooltipIcon text="More info" />
 ```
 
-##### Props
+## API
 
-- `text` – tooltip text displayed on hover.
-- `iconClass` – additional CSS classes applied to the icon.
-- `pt` – passthrough options to customize internal elements.
+### Props
 
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| text | `string \| null` | `null` | Tooltip text displayed on hover. |
+| iconClass | `string` | `'size-5'` | Additional CSS classes applied to the icon. |
+| pt | `object` | `undefined` | Pass-through options to customize internal elements. |
+
+### Slots
+
+None.
+
+### Events
+
+None.
+
+Refer to the [PrimeVue Tooltip API](https://primevue.org/tooltip/#api).

--- a/docs/ui/TooltipInfo.md
+++ b/docs/ui/TooltipInfo.md
@@ -1,23 +1,37 @@
 # TooltipInfo
+
+TooltipInfo shows a clickable info icon that reveals a popover.
+
 ```ts
 import { TooltipInfo } from '@atlas/ui';
 ```
 
+## Usage
+
 ```vue
 <TooltipInfo>
-    Details here
+  Details here
 </TooltipInfo>
 ```
 
-##### Props
+## API
 
-- `iconClass` – class for the info icon. Defaults to 'size-5'.
+### Props
 
-##### Events
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| pt | `object` | `undefined` | Pass-through options to customize internal elements. |
 
-- `toggle` – emitted with the visibility state when the popover is toggled.
+### Slots
 
-##### Slots
+| Name | Description |
+| ---- | ----------- |
+| default | Content displayed inside the popover. |
 
-- `default` – content displayed inside the popover.
+### Events
 
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| toggle | `boolean` | Emitted with visibility state when the popover is toggled. |
+
+Refer to the [PrimeVue Popover API](https://primevue.org/popover/#api).


### PR DESCRIPTION
## Summary
- document DataTable usage and API sections
- flesh out docs for Avatar, AvatarGroup, Chip, TooltipIcon, TooltipInfo, Table, TableActions, TableCustomizeColumns, and EditorContent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ad07929a8883258e64e1e2314a4a44