### PR TITLE
docs: update Feedback component docs

### DIFF
--- a/docs/ui/Alert.md
+++ b/docs/ui/Alert.md
@@ -1,14 +1,31 @@
 # Alert
+
+Displays a contextual inline message with optional icon and actions.
+
 ```ts
 import { Alert } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Alert>Default message</Alert>
 ```
 
-##### Props
+## API
 
-- `warning` – use warning styling.
-- `hideIcon` – hide the default icon.
+### Props
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `warning` | `boolean` | `false` | Use warning styling. |
+| `hideIcon` | `boolean` | `false` | Hide the default icon. |
+| `pt` | `AlertPassThroughOptions` | — | Pass-through options to customize internal elements. |
+
+### Slots
+- `default` – Content of the alert.
+- `icon` – Custom icon.
+- `actions` – Action elements such as buttons.
+
+### Events
+- None.
 

--- a/docs/ui/Errors.md
+++ b/docs/ui/Errors.md
@@ -1,22 +1,32 @@
 # Errors
+
+Displays a collapsible list of validation or request errors.
+
 ```ts
 import { Errors } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Errors :errors="formErrors" />
 ```
 
-##### Props
+## API
 
-- `errors` – record or array of error messages.
-- `failed` – show a default error message when true and no errors are provided.
-- `title` – optional heading text.
-- `expandDefault` – expand errors by default.
-- `pt` – passthrough options to customize internal elements.
+### Props
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `errors` | `Record<string, any> \| any[]` | `{}` | Record or array of error messages. |
+| `failed` | `boolean` | `false` | Show a default error message when true and no errors are provided. |
+| `title` | `string` | `''` | Optional heading text. |
+| `expandDefault` | `boolean` | `true` | Expand errors by default. |
+| `pt` | `ErrorsPassThroughOptions` | — | Pass-through options to customize internal elements. |
 
-##### Slots
+### Slots
+- `default` – Custom template for each error. Slot props: `{ error }`.
+- `defaultError` – Content shown when `failed` is true and no errors exist.
 
-- `default` – custom template for each error. Slot props: `{ error }`.
-- `defaultError` – content shown when `failed` is true and no errors exist.
+### Events
+- None.
 

--- a/docs/ui/ProgressBar.md
+++ b/docs/ui/ProgressBar.md
@@ -1,12 +1,31 @@
 # ProgressBar
+
+Wrapper around PrimeVue ProgressBar to display task progress.
+
 ```ts
 import { ProgressBar } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <ProgressBar :value="50" />
 ```
 
-##### API
+## API
+
+### Props
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `value` | `number` | `0` | Current progress value. |
+| `mode` | `'determinate' \| 'indeterminate'` | `'determinate'` | Progress display mode. |
+| `showValue` | `boolean` | `true` | Whether to show the value label. |
+| `pt` | `ProgressBarPassThroughOptions` | — | Pass-through options to customize internal elements. |
+
+### Slots
+- `default` – Custom content displayed inside the progress bar.
+
+### Events
+- None.
 
 Refer to the [PrimeVue ProgressBar API](https://primevue.org/progressbar/#api).

--- a/docs/ui/Toast.md
+++ b/docs/ui/Toast.md
@@ -1,13 +1,29 @@
 # Toast
+
+Wrapper around PrimeVue Toast for displaying transient notifications.
+
 ```ts
 import { Toast } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Toast />
 ```
 
-##### API
+## API
+
+### Props
+- None.
+
+### Slots
+- `icon` – Replaces the default status icon.
+- `closeicon` – Replaces the dismiss button icon.
+- `*` – Any other slots are forwarded to PrimeVue Toast.
+
+### Events
+- None.
 
 Refer to the [PrimeVue Toast API](https://primevue.org/toast/#api).
 


### PR DESCRIPTION
## Summary
- document Alert component with usage, API, and slot details
- expand Errors guide with structured props, slots, and events
- clarify Toast and ProgressBar docs and reference PrimeVue APIs
- list ProgressBar props in new API table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ad074278b883258db331cc35d1be69