### PR TITLE
docs: standardize form element guides

### DIFF
--- a/docs/ui/AutoComplete.md
+++ b/docs/ui/AutoComplete.md
@@ -1,13 +1,30 @@
 # AutoComplete
+
+AutoComplete is an input with dynamic suggestions.
+
 ```ts
 import { AutoComplete } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <AutoComplete v-model="value" :suggestions="items" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 See the [PrimeVue AutoComplete API](https://primevue.org/autocomplete/#api).
 

--- a/docs/ui/DatePicker.md
+++ b/docs/ui/DatePicker.md
@@ -1,13 +1,30 @@
 # DatePicker
+
+DatePicker is an input component for selecting dates.
+
 ```ts
 import { DatePicker } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <DatePicker v-model="date" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 See the [PrimeVue DatePicker API](https://primevue.org/datepicker/#api).
 

--- a/docs/ui/Editor.md
+++ b/docs/ui/Editor.md
@@ -1,24 +1,43 @@
 # Editor
 
-See the [Editor guide](../editor.md) for dependencies and usage.
-
+Editor is a rich text editor built with Tiptap. See the [Editor guide](../editor.md) for dependencies and usage.
 
 ```ts
 import { Editor } from '@atlas/ui';
 ```
 
+## Usage
+
 ```vue
 <Editor v-model="content" placeholder="Write something..." />
 ```
 
-##### Props
+## API
 
-- `modelValue` – bound editor content.
-- `placeholder` – placeholder text.
-- `editorClass` – additional classes for the editor area.
-- `autofocus` – focus editor on mount.
-- `toolbar` – show the formatting toolbar.
-- `toolbarOptions` – array of toolbar buttons to display.
-- `textOnly` – restrict to plain text input.
-- `toolbarClass` – additional classes for the toolbar.
+### Props
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `string \| null` | `undefined` | Bound editor content. |
+| `placeholder` | `string` | `''` | Placeholder text. |
+| `editorClass` | `string` | `'p-4 text-black text-sm dark:text-white'` | Additional classes for the editor area. |
+| `autofocus` | `boolean` | `false` | Focus editor on mount. |
+| `toolbar` | `boolean` | `true` | Show the formatting toolbar. |
+| `toolbarOptions` | `string[]` | `['bold', 'italic', 'strike', 'bullet', 'ordered', 'link', 'clear']` | Array of toolbar buttons to display. |
+| `textOnly` | `boolean` | `false` | Restrict to plain text input. |
+| `toolbarClass` | `string` | `'border-b border-surface-300 dark:border-surface-700'` | Additional classes for the toolbar. |
+
+### Slots
+
+| Name | Description |
+| ---- | ----------- |
+| `toolbar` | Customize the toolbar content. |
+
+### Events
+
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `string` | Emitted with the current content. |
+
+No PrimeVue equivalent.
 

--- a/docs/ui/FileUpload.md
+++ b/docs/ui/FileUpload.md
@@ -1,66 +1,61 @@
 # FileUpload
+
+FileUpload is a styled file input for selecting single or multiple files.
+
 ```ts
 import { FileUpload } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue';
 
 const file = ref<File | null>(null);
-
-const submit = async () => {
-    if (!file.value) return;
-
-    const form = new FormData();
-    form.append('file', file.value);
-
-    await fetch('/upload', { method: 'POST', body: form });
-};
 </script>
 
 <template>
-  <form @submit.prevent="submit">
-    <FileUpload v-model="file" clearable />
-    <button type="submit">Upload</button>
-  </form>
+  <FileUpload v-model="file" clearable />
 </template>
 ```
 
-Use `v-model` to bind the selected file or files. Submit them with `FormData` to upload to your server. When `multiple` is true, `modelValue` becomes an array and each file should be appended separately.
+Use `v-model` to bind the selected file or files. When `multiple` is true, `modelValue` becomes an array and each file should be appended to `FormData` separately.
 
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue';
 
 const files = ref<File[]>([]);
-
-const submit = async () => {
-    const form = new FormData();
-    files.value.forEach((file, i) => form.append(`files[${i}]`, file));
-    await fetch('/upload', { method: 'POST', body: form });
-};
 </script>
 
 <template>
-  <form @submit.prevent="submit">
-    <FileUpload v-model="files" multiple clearable />
-    <button type="submit">Upload</button>
-  </form>
+  <FileUpload v-model="files" multiple clearable />
 </template>
 ```
 
-##### Props
+## API
 
-- `modelValue` – selected `File` or `File[]`.
-- `multiple` – allow selecting multiple files.
-- `clearable` – show a clear button to reset the selection.
-- `chooseLabel` – text for the choose button.
-- `size` – `'small' | 'large'` to match `InputText` heights (34 px and 42 px).
-- `invalid` – show the error style with a red border.
+### Props
 
-##### Events
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `File \| File[] \| null` | `null` | Selected file or files. |
+| `multiple` | `boolean` | `false` | Allow selecting multiple files. |
+| `clearable` | `boolean` | `false` | Show a clear button to reset the selection. |
+| `chooseLabel` | `string` | `'Choose'` | Text for the choose button. |
+| `size` | `'small' \| 'large'` | `undefined` | Match InputText heights (34 px or 42 px). |
+| `invalid` | `boolean` | `false` | Show the error style with a red border. |
 
-- `update:modelValue` – emitted with the selected file or files.
+### Slots
 
+None.
+
+### Events
+
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `File \| File[] \| null` | Emitted with the selected file or files. |
+
+No PrimeVue equivalent.
 

--- a/docs/ui/InputGroup.md
+++ b/docs/ui/InputGroup.md
@@ -1,7 +1,12 @@
 # InputGroup
+
+InputGroup groups multiple components as a single input with shared borders.
+
 ```ts
 import { InputGroup, InputText, Button } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <InputGroup>
@@ -10,7 +15,19 @@ import { InputGroup, InputText, Button } from '@atlas/ui';
 </InputGroup>
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue InputGroup API](https://primevue.org/inputgroup/#api).
 

--- a/docs/ui/InputMask.md
+++ b/docs/ui/InputMask.md
@@ -1,13 +1,30 @@
 # InputMask
+
+InputMask is an input component with a mask to control the format of user input.
+
 ```ts
 import { InputMask } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <InputMask mask="99/99/9999" v-model="value" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue InputMask API](https://primevue.org/inputmask/#api).
 

--- a/docs/ui/InputNumber.md
+++ b/docs/ui/InputNumber.md
@@ -1,13 +1,30 @@
 # InputNumber
+
+InputNumber is an input field for numeric values with theming.
+
 ```ts
 import { InputNumber } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <InputNumber v-model="value" />
 ```
 
-##### API
+## API
 
-See the [PrimeVue InputNumber API](https://primevue.org/inputnumber/#api).
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
+
+Refer to the [PrimeVue InputNumber API](https://primevue.org/inputnumber/#api).
 

--- a/docs/ui/InputOtp.md
+++ b/docs/ui/InputOtp.md
@@ -1,13 +1,30 @@
 # InputOtp
+
+InputOtp is an input component for entering one-time passwords.
+
 ```ts
 import { InputOtp } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <InputOtp v-model="code" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue InputOtp API](https://primevue.org/inputotp/#api).
 

--- a/docs/ui/LabelField.md
+++ b/docs/ui/LabelField.md
@@ -1,7 +1,12 @@
 # LabelField
+
+LabelField pairs a label and optional tooltip with a form field and displays validation errors.
+
 ```ts
 import { LabelField, InputText } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <LabelField label="Name" name="name" required tooltip="Enter full name">
@@ -9,11 +14,28 @@ import { LabelField, InputText } from '@atlas/ui';
 </LabelField>
 ```
 
-##### Props
+## API
 
-- `label` – text for the label.
-- `tooltip` – help text shown in a tooltip.
-- `name` – associates the label with an input.
-- `required` – display an asterisk when true.
-- `error` – validation message displayed below the field.
+### Props
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `label` | `string` | `''` | Text for the label. |
+| `tooltip` | `string` | `''` | Help text shown in a tooltip. |
+| `name` | `string` | `''` | Associates the label with an input. |
+| `required` | `boolean` | `false` | Display an asterisk when true. |
+| `error` | `string` | `''` | Validation message displayed below the field. |
+| `pt` | `LabelFieldPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
+
+### Slots
+
+| Name | Description |
+| ---- | ----------- |
+| `default` | Input element to label. |
+
+### Events
+
+None.
+
+No PrimeVue equivalent.
 

--- a/docs/ui/MultiSelect.md
+++ b/docs/ui/MultiSelect.md
@@ -1,13 +1,30 @@
 # MultiSelect
+
+MultiSelect is a dropdown for selecting multiple options.
+
 ```ts
 import { MultiSelect } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <MultiSelect v-model="selected" :options="options" optionLabel="name" optionValue="value" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue MultiSelect API](https://primevue.org/multiselect/#api).
 

--- a/docs/ui/Password.md
+++ b/docs/ui/Password.md
@@ -1,13 +1,30 @@
 # Password
+
+Password is an input component for password values with a strength indicator and theming.
+
 ```ts
 import { Password } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Password v-model="value" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 See the [PrimeVue Password API](https://primevue.org/password/#api).
 

--- a/docs/ui/Select.md
+++ b/docs/ui/Select.md
@@ -1,13 +1,30 @@
 # Select
+
+Select is a dropdown input for selecting a single option.
+
 ```ts
 import { Select } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Select :options="options" v-model="selected" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 See the [PrimeVue Select API](https://primevue.org/select/#api).
 

--- a/docs/ui/Slider.md
+++ b/docs/ui/Slider.md
@@ -1,13 +1,30 @@
 # Slider
+
+Slider is an input component for selecting a numeric value on a range.
+
 ```ts
 import { Slider } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Slider v-model="value" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 See the [PrimeVue Slider API](https://primevue.org/slider/#api).
 

--- a/docs/ui/Textarea.md
+++ b/docs/ui/Textarea.md
@@ -1,13 +1,30 @@
 # Textarea
+
+Textarea is a multi-line text input with theming.
+
 ```ts
 import { Textarea } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Textarea v-model="value" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue Textarea API](https://primevue.org/textarea/#api).
 

--- a/docs/ui/ToggleButton.md
+++ b/docs/ui/ToggleButton.md
@@ -1,13 +1,30 @@
 # ToggleButton
+
+ToggleButton is a two-state button component.
+
 ```ts
 import { ToggleButton } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <ToggleButton v-model="checked" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue ToggleButton API](https://primevue.org/togglebutton/#api).
 

--- a/docs/ui/ToggleSwitch.md
+++ b/docs/ui/ToggleSwitch.md
@@ -1,12 +1,29 @@
 # ToggleSwitch
+
+ToggleSwitch is a switch component for boolean values.
+
 ```ts
 import { ToggleSwitch } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <ToggleSwitch v-model="checked" />
 ```
 
-##### API
+## API
+
+### Props
+
+None.
+
+### Slots
+
+None.
+
+### Events
+
+None.
 
 Refer to the [PrimeVue ToggleSwitch API](https://primevue.org/toggleswitch/#api).


### PR DESCRIPTION
## Summary
- rewrite Form Elements component docs to match current guidelines
- add missing descriptions, usage examples, and API sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ad088606e48325b0deca0d9317e3ea