### PR TITLE
docs: standardize navigation component guides

### DIFF
--- a/docs/ui/ButtonMenu.md
+++ b/docs/ui/ButtonMenu.md
@@ -15,18 +15,25 @@ import { ButtonMenu } from '@atlas/ui';
 ## API
 
 ### Props
-| Prop | Type | Description |
-| ---- | ---- | ----------- |
-| `items` | `MenuItem[]` | Menu items with `label`, `icon`, `action`, `disabled`, optional `children` for submenus, and `tooltip`. |
-| `icon` | `string` | Icon class for the default trigger. Defaults to `'pi pi-ellipsis-v'`. |
-| `ptData` | `Record<string, any>` | Additional data forwarded with the `action` event. |
-| `onHover` | `boolean` | Show menu on hover instead of click. Defaults to `false`. |
-| `pt` | `ButtonMenuPassThroughOptions` | Pass-through styling options. |
- 
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `items` | `MenuItem[]` | — | Menu items with `label`, `icon`, `action`, `disabled`, optional `children`, and `tooltip`. |
+| `icon` | `string` | `'pi pi-ellipsis-v'` | Icon class for the default trigger. |
+| `ptData` | `Record<string, any>` | `{}` | Additional data forwarded with the `action` event. |
+| `onHover` | `boolean` | `false` | Show menu on hover instead of click. |
+| `pt` | `ButtonMenuPassThroughOptions` | — | Pass-through styling options. |
+
 ### Slots
-- `trigger` – Custom trigger element. Slot props: `{ toggleMenu, triggerRef }`.
+
+| Name | Description |
+| ---- | ----------- |
+| `trigger` | Custom trigger element. Slot props: `{ toggleMenu, triggerRef }`. |
 
 ### Events
-- `action` – Emitted when an item is selected. Arguments: `(action: any, ptData: Record<string, any>)`.
+
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `action` | `(action: any, ptData: Record<string, any>)` | Emitted when an item is selected. |
 
 Refer to the [PrimeVue Menu API](https://primevue.org/menu/#api) for menu item options.

--- a/docs/ui/Menu.md
+++ b/docs/ui/Menu.md
@@ -1,12 +1,43 @@
 # Menu
+
+Displays a list of navigation items.
+
 ```ts
 import { Menu } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Menu :model="items" />
 ```
 
-##### API
+## API
+
+### Props
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `model` | `MenuItem[]` | — | Array of menu item objects. |
+| `popup` | `boolean` | `false` | Renders the menu as a popup overlay. |
+| `appendTo` | `string \\| HTMLElement` | `'body'` | Element or selector to append the overlay. |
+| `autoZIndex` | `boolean` | `true` | Whether to automatically manage layering. |
+| `baseZIndex` | `number` | `0` | Base z-index for layering. |
+| `pt` | `MenuPassThroughOptions` | — | Pass-through styling options. |
+
+### Slots
+| Name | Description |
+| ---- | ----------- |
+| `start` | Custom content before the menu. |
+| `end` | Custom content after the menu. |
+| `item` | Template for a menu item. |
+| `itemicon` | Custom icon template for a menu item. |
+
+### Events
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `show` | `void` | Emitted when the menu overlay is shown. |
+| `hide` | `void` | Emitted when the menu overlay is hidden. |
+| `focus` | `Event` | Emitted when the menu receives focus. |
+| `blur` | `Event` | Emitted when the menu loses focus. |
 
 Refer to the [PrimeVue Menu API](https://primevue.org/menu/#api).

--- a/docs/ui/Pagination.md
+++ b/docs/ui/Pagination.md
@@ -1,16 +1,33 @@
 # Pagination
+
+Simple pagination component rendering link elements.
+
 ```ts
 import { Pagination } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Pagination :links="links" />
 ```
 
-##### Props
+## API
 
-- `links` – array of pagination link objects.
-- `linkComponent` – component used for each link. Defaults to 'a'.
+### Props
 
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `links` | `PaginationLink[]` | — | Array of pagination link objects. |
+| `linkComponent` | `string \| object` | `'a'` | Component used for each link. |
+| `pt` | `PaginationPassThroughOptions` | — | Pass-through styling options. |
 
+### Slots
 
+None.
+
+### Events
+
+None.
+
+No PrimeVue equivalent.

--- a/docs/ui/Paginator.md
+++ b/docs/ui/Paginator.md
@@ -1,13 +1,41 @@
 # Paginator
+
+Pagination controls for navigating between pages of data.
+
 ```ts
 import { Paginator } from '@atlas/ui';
 ```
+
+## Usage
 
 ```vue
 <Paginator :totalRecords="100" :rows="10" />
 ```
 
-##### API
+## API
 
-See the [PrimeVue Paginator API](https://primevue.org/paginator/#api).
+### Props
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `totalRecords` | `number` | `0` | Number of total records. |
+| `rows` | `number` | `0` | Data count per page. |
+| `first` | `number` | `0` | Index of the first record to display. |
+| `pageLinkSize` | `number` | `5` | Number of page links to display. |
+| `rowsPerPageOptions` | `number[]` | — | Options for rows per page dropdown. |
+| `currentPageReportTemplate` | `string` | `({currentPage} of {totalPages})` | Template for the current page report. |
+| `pt` | `PaginatorPassThroughOptions` | — | Pass-through styling options. |
 
+### Slots
+| Name | Description |
+| ---- | ----------- |
+| `start` | Custom content before paginator controls. |
+| `end` | Custom content after paginator controls. |
+
+### Events
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `page` | `{ first: number; rows: number; page: number; pageCount: number }` | Callback when the page changes. |
+| `update:first` | `number` | Emitted when the `first` property changes. |
+| `update:rows` | `number` | Emitted when the `rows` property changes. |
+
+Refer to the [PrimeVue Paginator API](https://primevue.org/paginator/#api).


### PR DESCRIPTION
## Summary
- align ButtonMenu docs with current guidelines
- rewrite Menu docs to include usage and API sections
- bring Paginator and Pagination docs up to spec
- document props, slots, and events for Menu and Paginator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ad073c53d48325a2d5c5e14ccdf40f