### PR TITLE
docs: add api details for form elements

### DIFF
--- a/docs/ui/Checkbox.md
+++ b/docs/ui/Checkbox.md
@@ -15,16 +15,26 @@ import { Checkbox } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `any` | `false` | Checked value. |
+| `binary` | `boolean` | `false` | Uses true/false values instead of multiple selection. |
+| `trueValue` | `any` | `true` | Value to represent the checked state in binary mode. |
+| `falseValue` | `any` | `false` | Value to represent the unchecked state in binary mode. |
+| `disabled` | `boolean` | `false` | Disables the checkbox when true. |
+| `pt` | `CheckboxPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
 
 None.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `any` | Emitted when the value changes. |
+| `change` | `{ originalEvent: Event, checked: boolean, value: any }` | Triggered on value change. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when the checkbox receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when the checkbox loses focus. |
 
 Refer to the [PrimeVue Checkbox API](https://primevue.org/checkbox/#api).
 

--- a/docs/ui/InputMask.md
+++ b/docs/ui/InputMask.md
@@ -15,16 +15,27 @@ import { InputMask } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `string` | `''` | Bound value of the input. |
+| `mask` | `string` | `''` | Mask pattern defining the format. |
+| `slotChar` | `string` | `'_'` | Placeholder character used in the mask. |
+| `autoClear` | `boolean` | `true` | Clears the input if it does not complete the mask. |
+| `unmask` | `boolean` | `false` | Defines whether to remove mask characters in the bound value. |
+| `disabled` | `boolean` | `false` | Disables the input when true. |
+| `pt` | `InputMaskPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
 
 None.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `string` | Emitted when the value changes. |
+| `complete` | `{ originalEvent: Event }` | Triggered when the mask is fully completed. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when the input receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when the input loses focus. |
 
 Refer to the [PrimeVue InputMask API](https://primevue.org/inputmask/#api).
 

--- a/docs/ui/InputNumber.md
+++ b/docs/ui/InputNumber.md
@@ -15,16 +15,31 @@ import { InputNumber } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `number` | `undefined` | Bound numeric value. |
+| `min` | `number` | `undefined` | Minimum value. |
+| `max` | `number` | `undefined` | Maximum value. |
+| `step` | `number` | `1` | Incremental step when using buttons. |
+| `mode` | `'decimal' \| 'currency'` | `'decimal'` | Number formatting mode. |
+| `showButtons` | `boolean` | `false` | Shows increment and decrement buttons. |
+| `prefix` | `string` | `''` | Text to prefix the value. |
+| `suffix` | `string` | `''` | Text to append to the value. |
+| `disabled` | `boolean` | `false` | Disables the input when true. |
+| `pt` | `InputNumberPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
-
-None.
+- `incrementicon` – Custom icon for the increment button.
+- `decrementicon` – Custom icon for the decrement button.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `number` | Emitted when the value changes. |
+| `input` | `Event` | Browser input event. |
+| `change` | `number` | Triggered when the input loses focus and value changes. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when the input receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when the input loses focus. |
 
 Refer to the [PrimeVue InputNumber API](https://primevue.org/inputnumber/#api).
 

--- a/docs/ui/InputOtp.md
+++ b/docs/ui/InputOtp.md
@@ -15,16 +15,24 @@ import { InputOtp } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `string` | `''` | Bound OTP value. |
+| `length` | `number` | `6` | Number of input boxes. |
+| `integerOnly` | `boolean` | `false` | Restricts input to digits when true. |
+| `disabled` | `boolean` | `false` | Disables the inputs when true. |
+| `pt` | `InputOtpPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
-
-None.
+- `default` – Custom template for each input box.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `string` | Emitted when the value changes. |
+| `complete` | `{ originalEvent: Event }` | Fired when the last box is filled. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when any box receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when any box loses focus. |
 
 Refer to the [PrimeVue InputOtp API](https://primevue.org/inputotp/#api).
 

--- a/docs/ui/InputText.md
+++ b/docs/ui/InputText.md
@@ -15,16 +15,26 @@ import { InputText } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `string` | `''` | Bound value of the input. |
+| `type` | `string` | `'text'` | Native input type. |
+| `placeholder` | `string` | `''` | Placeholder text to display when empty. |
+| `disabled` | `boolean` | `false` | Disables the input when true. |
+| `clearable` | `boolean` | `false` | Displays a button to clear the value. |
+| `pt` | `InputTextPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
 
 None.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `string` | Emitted when the value changes. |
+| `input` | `Event` | Browser input event. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when the input receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when the input loses focus. |
 
 Refer to the [PrimeVue InputText API](https://primevue.org/inputtext/#api).
 

--- a/docs/ui/MultiSelect.md
+++ b/docs/ui/MultiSelect.md
@@ -15,16 +15,30 @@ import { MultiSelect } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `any[]` | `[]` | Selected option values. |
+| `options` | `any[]` | `[]` | List of available options. |
+| `optionLabel` | `string` | `undefined` | Property name or getter for the label. |
+| `optionValue` | `string` | `undefined` | Property name or getter for the value. |
+| `placeholder` | `string` | `''` | Placeholder text when no selection exists. |
+| `filter` | `boolean` | `false` | Enables client-side filtering. |
+| `display` | `'comma' \| 'chip'` | `'comma'` | Display mode of the selected items. |
+| `pt` | `MultiSelectPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
-
-None.
+- `value` – Template for the selected value display.
+- `option` – Template for an option in the panel.
+- `header` – Custom content above the options.
+- `footer` – Custom content below the options.
+- `empty` – Content shown when no options are available.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `change` | `{ originalEvent: Event, value: any[] }` | Emitted when the selection changes. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when the input receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when the input loses focus. |
 
 Refer to the [PrimeVue MultiSelect API](https://primevue.org/multiselect/#api).
 

--- a/docs/ui/RadioButton.md
+++ b/docs/ui/RadioButton.md
@@ -15,16 +15,25 @@ import { RadioButton } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `any` | `undefined` | Currently selected value. |
+| `value` | `any` | `undefined` | Value of the radio button option. |
+| `name` | `string` | `''` | Name of the radio group. |
+| `disabled` | `boolean` | `false` | Disables the radio button when true. |
+| `pt` | `RadioButtonPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
 
 None.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `any` | Emitted when the value changes. |
+| `change` | `{ originalEvent: Event, value: any }` | Triggered when the option is selected. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when the radio button receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when the radio button loses focus. |
 
 Refer to the [PrimeVue RadioButton API](https://primevue.org/radiobutton/#api).
 

--- a/docs/ui/Select.md
+++ b/docs/ui/Select.md
@@ -19,9 +19,11 @@ import { Select } from '@atlas/ui';
 | ---- | ---- | ------- | ----------- |
 | `modelValue` | `any` | — | Selected option value. |
 | `options` | `any[]` | `[]` | List of available options. |
-| `optionLabel` | `string` | — | Property name to use as the displayed label. |
+| `optionLabel` | `string` | `undefined` | Property name to use as the displayed label. |
+| `optionValue` | `string` | `undefined` | Property name to use as the value. |
+| `placeholder` | `string` | `''` | Placeholder text to show when no selection exists. |
 | `filter` | `boolean` | `false` | Enables client-side filtering. |
-| `pt` | `SelectPassThroughOptions` | — | Pass-through options to customize internal elements. |
+| `pt` | `SelectPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
 - `value` – Template for the selected value display.

--- a/docs/ui/Textarea.md
+++ b/docs/ui/Textarea.md
@@ -15,16 +15,28 @@ import { Textarea } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `string` | `''` | Bound value of the textarea. |
+| `autoResize` | `boolean` | `false` | Adjusts height based on content. |
+| `rows` | `number` | `5` | Number of visible text lines. |
+| `cols` | `number` | `20` | Visible character width. |
+| `maxlength` | `number` | `undefined` | Maximum number of characters allowed. |
+| `placeholder` | `string` | `''` | Placeholder text to display when empty. |
+| `disabled` | `boolean` | `false` | Disables the textarea when true. |
+| `pt` | `TextareaPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
 
 None.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `string` | Emitted when the value changes. |
+| `input` | `Event` | Browser input event. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when the textarea receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when the textarea loses focus. |
 
 Refer to the [PrimeVue Textarea API](https://primevue.org/textarea/#api).
 

--- a/docs/ui/ToggleButton.md
+++ b/docs/ui/ToggleButton.md
@@ -15,16 +15,27 @@ import { ToggleButton } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `boolean` | `false` | Bound value of the button. |
+| `onLabel` | `string` | `''` | Label when in checked state. |
+| `offLabel` | `string` | `''` | Label when in unchecked state. |
+| `onIcon` | `string` | `''` | Icon class for the checked state. |
+| `offIcon` | `string` | `''` | Icon class for the unchecked state. |
+| `iconPos` | `'left' \| 'right'` | `'left'` | Position of the icon. |
+| `disabled` | `boolean` | `false` | Disables the button when true. |
+| `pt` | `ToggleButtonPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
-
 None.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `boolean` | Emitted when the value changes. |
+| `change` | `{ originalEvent: Event, value: boolean }` | Triggered when the value changes. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when the button receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when the button loses focus. |
 
 Refer to the [PrimeVue ToggleButton API](https://primevue.org/togglebutton/#api).
 

--- a/docs/ui/ToggleSwitch.md
+++ b/docs/ui/ToggleSwitch.md
@@ -15,15 +15,23 @@ import { ToggleSwitch } from '@atlas/ui';
 ## API
 
 ### Props
-
-None.
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `modelValue` | `any` | `false` | Bound value of the switch. |
+| `trueValue` | `any` | `true` | Value to represent the checked state. |
+| `falseValue` | `any` | `false` | Value to represent the unchecked state. |
+| `disabled` | `boolean` | `false` | Disables the switch when true. |
+| `pt` | `ToggleSwitchPassThroughOptions` | `undefined` | Pass-through options to customize internal elements. |
 
 ### Slots
-
 None.
 
 ### Events
-
-None.
+| Name | Payload | Description |
+| ---- | ------- | ----------- |
+| `update:modelValue` | `any` | Emitted when the value changes. |
+| `change` | `{ originalEvent: Event, value: any }` | Triggered when the value changes. |
+| `focus` | `{ originalEvent: FocusEvent }` | Fired when the switch receives focus. |
+| `blur` | `{ originalEvent: FocusEvent }` | Fired when the switch loses focus. |
 
 Refer to the [PrimeVue ToggleSwitch API](https://primevue.org/toggleswitch/#api).


### PR DESCRIPTION
## Summary
- document API for form components like InputText, Checkbox, and Select
- add slots and events tables for MultiSelect, InputNumber, and more

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ad0d81bcc883258ffe657d148998c7