### PR TITLE
docs: update layout component guides

### DIFF
--- a/docs/ui/Accordion.md
+++ b/docs/ui/Accordion.md
@@ -20,10 +20,25 @@ import { Accordion, AccordionPanel, AccordionHeader, AccordionContent } from '@a
 ## API
 
 ### Props
-See the [PrimeVue Accordion API](https://primevue.org/accordion/#api) for a full list of props.
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `value` | `string \| string[] \| number \| number[] \| null` | `null` | Value of the active panel(s). |
+| `multiple` | `boolean` | `false` | Allow multiple panels to be active. |
+| `activeIndex` | `number \| number[] \| null` | `null` | **Deprecated.** Previous index of active panel. |
+| `lazy` | `boolean` | `false` | Whether hidden tabs are not rendered. |
+| `expandIcon` | `string` | `undefined` | Icon of a collapsed tab. |
+| `collapseIcon` | `string` | `undefined` | Icon of an expanded tab. |
+| `tabindex` | `number` | `0` | Tab order of the element. |
+| `selectOnFocus` | `boolean` | `false` | Activate tab on focus. |
+| `dt` | `DesignToken` | `undefined` | Design tokens for CSS variables. |
+| `pt` | `AccordionPassThroughOptions` | `undefined` | Pass-through attributes for DOM elements. |
+| `ptOptions` | `PassThroughOptions` | `undefined` | Configures pass-through options. |
+| `unstyled` | `boolean` | `false` | Removes component styles. |
 
 ### Slots
-See the [PrimeVue Accordion API](https://primevue.org/accordion/#api) for available slots.
+- `default` – Accordion panels.
 
 ### Events
-See the [PrimeVue Accordion API](https://primevue.org/accordion/#api) for emitted events.
+None.
+
+Refer to the [PrimeVue Accordion API](https://primevue.org/accordion/#api).

--- a/docs/ui/Card.md
+++ b/docs/ui/Card.md
@@ -18,9 +18,19 @@ import { Card } from '@atlas/ui';
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `noPadding` | `boolean` | `false` | Removes padding from the card's content section. |
+| `dt` | `DesignToken` | `undefined` | Design tokens for CSS variables. |
+| `pt` | `CardPassThroughOptions` | `undefined` | Pass-through attributes for DOM elements. |
+| `ptOptions` | `PassThroughOptions` | `undefined` | Configures pass-through options. |
+| `unstyled` | `boolean` | `false` | Removes component styles. |
 
 ### Slots
-See the [PrimeVue Card API](https://primevue.org/card/#api) for available slots.
+- `default` – Card content.
+- `header` – Custom header section.
+- `title` – Replaces the card title.
+- `subtitle` – Adds a subtitle below the title.
+- `footer` – Footer content.
 
 ### Events
-See the [PrimeVue Card API](https://primevue.org/card/#api) for emitted events.
+None.
+
+Refer to the [PrimeVue Card API](https://primevue.org/card/#api).

--- a/docs/ui/Dialog.md
+++ b/docs/ui/Dialog.md
@@ -20,10 +20,49 @@ import { Dialog, Button } from '@atlas/ui';
 ## API
 
 ### Props
-See the [PrimeVue Dialog API](https://primevue.org/dialog/#api) for a full list of props.
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `header` | `string` | `undefined` | Title content of the dialog. |
+| `footer` | `string` | `undefined` | Footer content of the dialog. |
+| `visible` | `boolean` | `false` | Controls visibility. |
+| `modal` | `boolean` | `false` | Blocks background when shown. |
+| `contentStyle` | `any` | `undefined` | Inline style of the content section. |
+| `contentClass` | `any` | `undefined` | Style class of the content section. |
+| `contentProps` | `HTMLAttributes` | `undefined` | Props for the overlay content element. |
+| `closable` | `boolean` | `true` | Adds a close icon to the header. |
+| `dismissableMask` | `boolean` | `false` | Hide on outside click of modal background. |
+| `closeOnEscape` | `boolean` | `true` | Hide when escape key is pressed. |
+| `showHeader` | `boolean` | `true` | Display the header. |
+| `blockScroll` | `boolean` | `false` | Prevent background scrolling. |
+| `baseZIndex` | `number` | `0` | Base z-index for layering. |
+| `autoZIndex` | `boolean` | `true` | Automatically manage layering. |
+| `position` | `'center' \| 'top' \| 'bottom' \| 'left' \| 'right' \| 'topleft' \| 'topright' \| 'bottomleft' \| 'bottomright'` | `'center'` | Initial position of the dialog. |
+| `maximizable` | `boolean` | `false` | Allow full-screen mode. |
+| `breakpoints` | `DialogBreakpoints` | `undefined` | Responsive width options. |
+| `draggable` | `boolean` | `true` | Enable moving by dragging the header. |
+| `keepInViewport` | `boolean` | `true` | Restrict dragging within viewport. |
+| `minX` | `number` | `0` | Minimum left coordinate when dragging. |
+| `minY` | `number` | `0` | Minimum top coordinate when dragging. |
+| `appendTo` | `'body' \| 'self' \| HTMLElement` | `'body'` | DOM element to attach the dialog. |
+| `style` | `any` | `undefined` | Style of the dialog container. |
+| `closeIcon` | `string` | `undefined` | Icon for the close button. |
+| `maximizeIcon` | `string` | `undefined` | Icon when dialog is not maximized. |
+| `minimizeIcon` | `string` | `undefined` | Icon when dialog is maximized. |
+| `closeButtonProps` | `object` | `{ severity: 'secondary', rounded: true, text: true }` | Props for the close button. |
+| `maximizeButtonProps` | `object` | `{ severity: 'secondary', rounded: true, text: true }` | Props for the maximize button. |
+| `dt` | `DesignToken` | `undefined` | Design tokens for CSS variables. |
+| `pt` | `DialogPassThroughOptions` | `undefined` | Pass-through attributes for DOM elements. |
+| `ptOptions` | `PassThroughOptions` | `undefined` | Configures pass-through options. |
+| `unstyled` | `boolean` | `false` | Removes component styles. |
 
 ### Slots
-See the [PrimeVue Dialog API](https://primevue.org/dialog/#api) for available slots.
+- `default` – Dialog content.
+- `header` – Custom header content.
+- `footer` – Footer section.
+- `closebutton` – Replaces the close button.
+- `maximizebutton` – Replaces the maximize button.
 
 ### Events
-See the [PrimeVue Dialog API](https://primevue.org/dialog/#api) for emitted events.
+None.
+
+Refer to the [PrimeVue Dialog API](https://primevue.org/dialog/#api).

--- a/docs/ui/DialogConfirmation.md
+++ b/docs/ui/DialogConfirmation.md
@@ -24,10 +24,14 @@ import { DialogConfirmation } from '@atlas/ui';
 | `loading` | `boolean` | `false` | Disables buttons and shows loading state. |
 | `pt` | `DialogConfirmationPassThroughOptions` | `undefined` | Passthrough options for internal elements. |
 
+Also supports all PrimeVue Dialog props except `visible`, `header`, and `pt`.
+
 ### Slots
-- `message` – custom confirmation message and icon.
-- `actions` – replace the default action buttons.
+- `message` – Custom confirmation message and icon.
+- `actions` – Replace the default action buttons.
 
 ### Events
-- `update:modelValue` – emitted when visibility changes.
-- `confirm` – emitted when the confirm action is triggered.
+- `update:modelValue` – Emitted when visibility changes.
+- `confirm` – Emitted when the confirm action is triggered.
+
+Refer to the [PrimeVue Dialog API](https://primevue.org/dialog/#api).

--- a/docs/ui/Divider.md
+++ b/docs/ui/Divider.md
@@ -15,10 +15,20 @@ import { Divider } from '@atlas/ui';
 ## API
 
 ### Props
-See the [PrimeVue Divider API](https://primevue.org/divider/#api) for a full list of props.
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `align` | `'left' \| 'center' \| 'right' \| 'top' \| 'bottom'` | `undefined` | Alignment of the content. |
+| `layout` | `'horizontal' \| 'vertical'` | `'horizontal'` | Orientation of the divider. |
+| `type` | `'solid' \| 'dashed' \| 'dotted'` | `'solid'` | Border style type. |
+| `dt` | `DesignToken` | `undefined` | Design tokens for CSS variables. |
+| `pt` | `DividerPassThroughOptions` | `undefined` | Pass-through attributes for DOM elements. |
+| `ptOptions` | `PassThroughOptions` | `undefined` | Configures pass-through options. |
+| `unstyled` | `boolean` | `false` | Removes component styles. |
 
 ### Slots
-See the [PrimeVue Divider API](https://primevue.org/divider/#api) for available slots.
+- `default` – Custom content inside the divider.
 
 ### Events
-See the [PrimeVue Divider API](https://primevue.org/divider/#api) for emitted events.
+None.
+
+Refer to the [PrimeVue Divider API](https://primevue.org/divider/#api).

--- a/docs/ui/Drawer.md
+++ b/docs/ui/Drawer.md
@@ -17,10 +17,31 @@ import { Drawer } from '@atlas/ui';
 ## API
 
 ### Props
-See the [PrimeVue Drawer API](https://primevue.org/drawer/#api) for a full list of props.
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `visible` | `boolean` | `false` | Controls visibility. |
+| `position` | `'left' \| 'right' \| 'top' \| 'bottom' \| 'full'` | `'left'` | Drawer attachment edge. |
+| `header` | `string` | `undefined` | Title content. |
+| `baseZIndex` | `number` | `0` | Base z-index for layering. |
+| `autoZIndex` | `boolean` | `true` | Automatically manage layering. |
+| `dismissable` | `boolean` | `true` | Hide when background is clicked. |
+| `showCloseIcon` | `boolean` | `true` | Display close icon. |
+| `closeButtonProps` | `object` | `{ severity: 'secondary', text: true, rounded: true }` | Props for the close button. |
+| `closeIcon` | `string` | `undefined` | Icon for the close button. |
+| `modal` | `boolean` | `true` | Add modal overlay. |
+| `blockScroll` | `boolean` | `false` | Prevent background scrolling. |
+| `dt` | `DesignToken` | `undefined` | Design tokens for CSS variables. |
+| `pt` | `DrawerPassThroughOptions` | `undefined` | Pass-through attributes for DOM elements. |
+| `ptOptions` | `PassThroughOptions` | `undefined` | Configures pass-through options. |
+| `unstyled` | `boolean` | `false` | Removes component styles. |
 
 ### Slots
-See the [PrimeVue Drawer API](https://primevue.org/drawer/#api) for available slots.
+- `default` – Drawer content.
+- `header` – Custom header content.
+- `footer` – Footer section.
+- `closebutton` – Replaces the close button.
 
 ### Events
-See the [PrimeVue Drawer API](https://primevue.org/drawer/#api) for emitted events.
+None.
+
+Refer to the [PrimeVue Drawer API](https://primevue.org/drawer/#api).

--- a/docs/ui/DrawerForm.md
+++ b/docs/ui/DrawerForm.md
@@ -28,14 +28,16 @@ import { DrawerForm } from '@atlas/ui';
 | `modelActiveTab` | `number` | `0` | Index of the active tab. |
 
 ### Slots
-- `header` – custom header content.
-- `default` – form content or first tab panel.
-- `tab-{index}` – content for the tab at the specified index.
-- `footer` – custom footer content.
-- `message` – message above footer actions.
-- `actions` – replace default footer actions.
+- `header` – Custom header content.
+- `default` – Form content or first tab panel.
+- `tab-{index}` – Content for the tab at the specified index.
+- `footer` – Custom footer content.
+- `message` – Message above footer actions.
+- `actions` – Replace default footer actions.
 
 ### Events
-- `update:modelValue` – emitted when visibility changes.
-- `submit` – emitted when the save action is triggered.
-- `update:modelActiveTab` – emitted when active tab changes.
+- `update:modelValue` – Emitted when visibility changes.
+- `submit` – Emitted when the save action is triggered.
+- `update:modelActiveTab` – Emitted when active tab changes.
+
+Refer to the [PrimeVue Drawer API](https://primevue.org/drawer/#api).

--- a/docs/ui/Popover.md
+++ b/docs/ui/Popover.md
@@ -18,10 +18,24 @@ import { Popover, Button } from '@atlas/ui';
 ## API
 
 ### Props
-See the [PrimeVue Popover API](https://primevue.org/popover/#api) for a full list of props.
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `dismissable` | `boolean` | `true` | Hide when outside is clicked. |
+| `appendTo` | `'body' \| 'self' \| HTMLElement` | `'body'` | Where the overlay is attached. |
+| `baseZIndex` | `number` | `0` | Base z-index for layering. |
+| `autoZIndex` | `boolean` | `true` | Automatically manage layering. |
+| `breakpoints` | `PopoverBreakpoints` | `undefined` | Responsive width options. |
+| `dt` | `DesignToken` | `undefined` | CSS design tokens. |
+| `pt` | `PopoverPassThroughOptions` | `undefined` | Pass-through attributes for DOM elements. |
+| `ptOptions` | `PassThroughOptions` | `undefined` | Configure pass-through options. |
+| `unstyled` | `boolean` | `false` | Removes component styles. |
+| `closeOnEscape` | `boolean` | `true` | Hide when escape key is pressed. |
 
 ### Slots
-See the [PrimeVue Popover API](https://primevue.org/popover/#api) for available slots.
+- `default` – Target element that triggers the popover.
+- `content` – Content displayed inside the popover.
 
 ### Events
-See the [PrimeVue Popover API](https://primevue.org/popover/#api) for emitted events.
+None.
+
+Refer to the [PrimeVue Popover API](https://primevue.org/popover/#api).

--- a/docs/ui/ScrollFrame.md
+++ b/docs/ui/ScrollFrame.md
@@ -35,4 +35,5 @@ import { ScrollFrame } from '@atlas/ui';
 - `default` – scrollable content.
 
 ### Events
-- None.
+
+None.

--- a/docs/ui/Tabs.md
+++ b/docs/ui/Tabs.md
@@ -24,10 +24,23 @@ import { Tabs, Tab, TabList, TabPanel, TabPanels } from '@atlas/ui';
 ## API
 
 ### Props
-See the [PrimeVue Tabs API](https://primevue.org/tabs/#api) for a full list of props.
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `value` | `string \| number` | `undefined` | Value of the active tab. |
+| `lazy` | `boolean` | `false` | Whether hidden tabs are not rendered. |
+| `scrollable` | `boolean` | `false` | Enable scrollable tab headers. |
+| `showNavigators` | `boolean` | `true` | Show navigation buttons when scrollable. |
+| `tabindex` | `number` | `0` | Tab order of the container. |
+| `selectOnFocus` | `boolean` | `false` | Activate tab on focus. |
+| `dt` | `DesignToken` | `undefined` | Design tokens for CSS variables. |
+| `pt` | `TabsPassThroughOptions` | `undefined` | Pass-through attributes for DOM elements. |
+| `ptOptions` | `PassThroughOptions` | `undefined` | Configures pass-through options. |
+| `unstyled` | `boolean` | `false` | Removes component styles. |
 
 ### Slots
-See the [PrimeVue Tabs API](https://primevue.org/tabs/#api) for available slots.
+- `default` – Contains `TabList` and `TabPanels` components.
 
 ### Events
-See the [PrimeVue Tabs API](https://primevue.org/tabs/#api) for emitted events.
+None.
+
+Refer to the [PrimeVue Tabs API](https://primevue.org/tabs/#api).

--- a/docs/ui/Topbar.md
+++ b/docs/ui/Topbar.md
@@ -25,4 +25,5 @@ import { Topbar } from '@atlas/ui';
 - `default` – bar content.
 
 ### Events
-- None.
+
+None.


### PR DESCRIPTION
## Summary
- document Accordion and other layout components with explicit PrimeVue props
- detail Card, Dialog and Drawer attributes and defaults
- note DialogConfirmation's support for standard Dialog props

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ad0d637ccc8325a462bea8067607ea